### PR TITLE
Feature/95 feature 업무관리 게시글 생성 기능 2차 구현

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
@@ -1,0 +1,27 @@
+package com.checkping.api.controller;
+
+import com.checkping.common.response.BaseResponse;
+import com.checkping.dto.TaskBoardRequest;
+import com.checkping.dto.TaskBoardResponse;
+import com.checkping.service.project.TaskBoardService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class TaskBoardController {
+
+    private final TaskBoardService taskBoardService;
+
+    @PostMapping("/posts")
+    public BaseResponse<TaskBoardResponse.TaskBoardDto> register(@RequestBody TaskBoardRequest.RegisterDto request) {
+
+        TaskBoardResponse.TaskBoardDto taskBoardDto = taskBoardService.register(request);
+
+        return BaseResponse.success(taskBoardDto);
+    }
+}

--- a/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
+++ b/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
@@ -76,11 +76,13 @@ public class TaskBoard extends BaseEntity {
     @Column(name = "board_category", nullable = false, length = 100)
     private BoardCategory boardCategory;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "board_status", nullable = false, length = 100)
     private BoardStatus boardStatus;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "deleted_yn", nullable = false)
-    private Character deletedYn;
+    private DeleteStatus deletedYn;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
@@ -97,6 +99,13 @@ public class TaskBoard extends BaseEntity {
     @RequiredArgsConstructor
     public enum BoardStatus {
         PROGRESS("진행중"), COMPLETED("완료"), SUSPENSION("보류"), PERMISSION_REQUEST("승인 요청");
+        private final String description;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum DeleteStatus {
+        Y("비활성화"), N("활성화");
         private final String description;
     }
 }

--- a/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
+++ b/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
@@ -45,7 +45,6 @@ public class TaskBoard extends BaseEntity {
     boardStatus : 게시글 상태
     deletedYn : 삭제 여부
     parent : 부모 게시글
-    replyList : 답글 리스트
      */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
+++ b/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
@@ -51,8 +51,9 @@ public class TaskBoard extends BaseEntity {
     @Column(name = "id", nullable = false)
     private Long id;
 
+    @Builder.Default
     @Column(name = "number", nullable = false)
-    private Integer number;
+    private Integer number = 1;
 
     @Column(name = "title", nullable = false, length = 100)
     private String title;

--- a/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
+++ b/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
@@ -108,4 +108,14 @@ public class TaskBoard extends BaseEntity {
         Y("비활성화"), N("활성화");
         private final String description;
     }
+
+    // soft delete 적용 = 게시글 비활성화
+    public void deactivate() {
+        this.deletedYn = DeleteStatus.Y;
+    }
+
+    // soft delete 해제 = 게시글 활성화
+    public void activate() {
+        this.deletedYn = DeleteStatus.N;
+    }
 }

--- a/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
+++ b/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
@@ -86,9 +86,6 @@ public class TaskBoard extends BaseEntity {
     @JoinColumn(name = "parent_id")
     private TaskBoard parent;
 
-    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
-    private List<TaskBoard> replyList = new ArrayList<>();
-
     @Getter
     @RequiredArgsConstructor
     public enum BoardCategory {

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/TaskBoardRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/TaskBoardRepository.java
@@ -1,0 +1,10 @@
+package com.checkping.infra.repository.project;
+
+import com.checkping.domain.board.TaskBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TaskBoardRepository extends JpaRepository<TaskBoard, Long> {
+
+}

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/TaskBoardStore.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/TaskBoardStore.java
@@ -1,0 +1,8 @@
+package com.checkping.infra.repository.project;
+
+import com.checkping.domain.board.TaskBoard;
+
+public interface TaskBoardStore {
+
+    TaskBoard store(TaskBoard taskBoard);
+}

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/TaskBoardStoreImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/TaskBoardStoreImpl.java
@@ -1,0 +1,16 @@
+package com.checkping.infra.repository.project;
+
+import com.checkping.domain.board.TaskBoard;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TaskBoardStoreImpl implements TaskBoardStore {
+    private final TaskBoardRepository taskBoardRepository;
+
+    @Override
+    public TaskBoard store(TaskBoard taskBoard) {
+        return taskBoardRepository.save(taskBoard);
+    }
+}

--- a/module-service/src/main/java/com/checkping/dto/TaskBoardRequest.java
+++ b/module-service/src/main/java/com/checkping/dto/TaskBoardRequest.java
@@ -1,0 +1,65 @@
+package com.checkping.dto;
+
+import com.checkping.domain.board.TaskBoard;
+import com.checkping.exception.project.TaskBoardInvalidBoardCategoryException;
+import com.checkping.exception.project.TaskBoardInvalidBoardStatusException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TaskBoardRequest {
+
+    @Getter
+    @ToString
+    public static class RegisterDto {
+        /*
+        title : 게시글 제목
+        content : 게시글 본문 내용
+        boardCategory : 게시글 카테고리 (enum, String)
+        boardStatus : 게시글 상태 (enum, String)
+         */
+        private String title;
+        private String content;
+        private String boardCategory;
+        private String boardStatus;
+
+        public static TaskBoard toEntity(RegisterDto registerDto) {
+            return TaskBoard.builder()
+                .title(registerDto.getTitle())
+                .content(registerDto.getContent())
+                .boardCategory(TaskBoardRequest.convertBoardCategory(registerDto.getBoardCategory()))
+                .boardStatus(TaskBoardRequest.convertBoardStatus(registerDto.getBoardStatus()))
+                .build();
+        }
+    }
+
+    /**
+     * Enum : BoardCategory 변환 함수
+     *
+     * @param value BoardCategory 로 변환할 문자열
+     * @return TaskBoard.BoardCategory
+     */
+    public static TaskBoard.BoardCategory convertBoardCategory(String value) {
+        try {
+            return TaskBoard.BoardCategory.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new TaskBoardInvalidBoardCategoryException(value);
+        }
+    }
+
+    /**
+     * Enum : BoardStatus 변환 함수
+     *
+     * @param value BoardStatus 로 변환할 문자열
+     * @return TaskBoard.BoardStatus
+     */
+    public static TaskBoard.BoardStatus convertBoardStatus(String value) {
+        try {
+            return TaskBoard.BoardStatus.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new TaskBoardInvalidBoardStatusException(value);
+        }
+    }
+}

--- a/module-service/src/main/java/com/checkping/dto/TaskBoardResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/TaskBoardResponse.java
@@ -1,0 +1,52 @@
+package com.checkping.dto;
+
+import com.checkping.domain.board.TaskBoard;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+public class TaskBoardResponse {
+
+    @Getter
+    @Setter
+    @ToString
+    public static class TaskBoardDto {
+        /*
+        id : 게시글 고유 ID
+        number : 게시글 번호
+        title : 게시글 제목
+        content : 게시글 본문 내용
+        regAt : 게시글 작성 일시
+        editAt : 게시글 마지막 수정 일시
+        approverAt : 게시글 승인 일시
+        boardCategory : 게시글 카테고리 (enum, String)
+        boardStatus : 게시글 상태 (enum, String)
+        deletedYn : 게시글 삭제 여부 ('Y' 또는 'N')
+         */
+        private Long id;
+        private Integer number;
+        private String title;
+        private String content;
+        private LocalDateTime regAt;
+        private LocalDateTime editAt;
+        private LocalDateTime approverAt;
+        private TaskBoard.BoardCategory boardCategory;
+        private TaskBoard.BoardStatus boardStatus;
+        private TaskBoard.DeleteStatus deletedYn;
+
+        public static TaskBoardDto toDto(TaskBoard taskBoard) {
+            TaskBoardDto boardDto = new TaskBoardDto();
+            boardDto.setId(taskBoard.getId());
+            boardDto.setNumber(taskBoard.getNumber());
+            boardDto.setTitle(taskBoard.getTitle());
+            boardDto.setContent(taskBoard.getContent());
+            boardDto.setRegAt(taskBoard.getRegAt());
+            boardDto.setEditAt(taskBoard.getEditAt());
+            boardDto.setApproverAt(taskBoard.getApproverAt());
+            boardDto.setBoardCategory(taskBoard.getBoardCategory());
+            boardDto.setBoardStatus(taskBoard.getBoardStatus());
+            return boardDto;
+        }
+    }
+}

--- a/module-service/src/main/java/com/checkping/exception/project/TaskBoardException.java
+++ b/module-service/src/main/java/com/checkping/exception/project/TaskBoardException.java
@@ -1,0 +1,19 @@
+package com.checkping.exception.project;
+
+import com.checkping.common.enums.ErrorCode;
+import com.checkping.common.exception.BaseException;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TaskBoardException extends BaseException {
+
+    public TaskBoardException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public TaskBoardException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/module-service/src/main/java/com/checkping/exception/project/TaskBoardInvalidBoardCategoryException.java
+++ b/module-service/src/main/java/com/checkping/exception/project/TaskBoardInvalidBoardCategoryException.java
@@ -1,0 +1,10 @@
+package com.checkping.exception.project;
+
+import com.checkping.common.enums.ErrorCode;
+
+public class TaskBoardInvalidBoardCategoryException extends TaskBoardException {
+
+    public TaskBoardInvalidBoardCategoryException(String value) {
+        super("허용되는 게시글 유형이 아닙니다. BoardCategory : {}" + value, ErrorCode.BAD_REQUEST);
+    }
+}

--- a/module-service/src/main/java/com/checkping/exception/project/TaskBoardInvalidBoardStatusException.java
+++ b/module-service/src/main/java/com/checkping/exception/project/TaskBoardInvalidBoardStatusException.java
@@ -1,0 +1,10 @@
+package com.checkping.exception.project;
+
+import com.checkping.common.enums.ErrorCode;
+
+public class TaskBoardInvalidBoardStatusException extends TaskBoardException {
+
+    public TaskBoardInvalidBoardStatusException(String value) {
+        super("허용되는 게시글 상태가 아닙니다. BoardCategory : {}" + value, ErrorCode.BAD_REQUEST);
+    }
+}

--- a/module-service/src/main/java/com/checkping/service/project/TaskBoardService.java
+++ b/module-service/src/main/java/com/checkping/service/project/TaskBoardService.java
@@ -1,0 +1,8 @@
+package com.checkping.service.project;
+
+import com.checkping.dto.TaskBoardRequest;
+import com.checkping.dto.TaskBoardResponse;
+
+public interface TaskBoardService {
+    TaskBoardResponse.TaskBoardDto register(TaskBoardRequest.RegisterDto request);
+}

--- a/module-service/src/main/java/com/checkping/service/project/TaskBoardServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/TaskBoardServiceImpl.java
@@ -1,0 +1,32 @@
+package com.checkping.service.project;
+
+import com.checkping.domain.board.TaskBoard;
+import com.checkping.dto.TaskBoardRequest;
+import com.checkping.dto.TaskBoardResponse;
+import com.checkping.infra.repository.project.TaskBoardStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TaskBoardServiceImpl implements TaskBoardService {
+
+    private final TaskBoardStore taskBoardStore;
+
+    /**
+     * 업무 관리 게시글 등록하기
+     *
+     * @param request 업무 관리 게시글에 필요한 request
+     * @return 생성한 TaskBoard 의 Dto
+     */
+    @Override
+    public TaskBoardResponse.TaskBoardDto register(TaskBoardRequest.RegisterDto request) {
+
+        TaskBoard initTaskBoard = TaskBoardRequest.RegisterDto.toEntity(request);
+        initTaskBoard.activate();
+
+        TaskBoard taskBoard = taskBoardStore.store(initTaskBoard);
+
+        return TaskBoardResponse.TaskBoardDto.toDto(taskBoard);
+    }
+}

--- a/module-service/src/main/java/com/checkping/service/project/TaskBoardServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/TaskBoardServiceImpl.java
@@ -22,11 +22,14 @@ public class TaskBoardServiceImpl implements TaskBoardService {
     @Override
     public TaskBoardResponse.TaskBoardDto register(TaskBoardRequest.RegisterDto request) {
 
+        // dto -> entity
         TaskBoard initTaskBoard = TaskBoardRequest.RegisterDto.toEntity(request);
         initTaskBoard.activate();
 
+        // save entity
         TaskBoard taskBoard = taskBoardStore.store(initTaskBoard);
 
+        // entity -> dto
         return TaskBoardResponse.TaskBoardDto.toDto(taskBoard);
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

**[업무관리 게시글 생성 기능 2차 구현]**

## #️⃣ 연관된 이슈

- #95 
- #74 
- #78 
- #85 

## 📋 작업 내용

### TaskBoardException
- TaskBoardException 추가
- TaskBoardInvalidBoardCategoryException 추가 (TaskBoardException 상속받음)
- TaskBoardInvalidBoardCategoryException 추가 (TaskBoardException 상속받음)

### TaskBoardRequest
- TaskBoardRequest.convertBoardCategory, TaskBoardRequest.convertBoardStatus 추가
  - RequestDto 가 entity 로 변환하는 역할을 맡음(convention)
  - convertBoardCategory 의 역할 상 common, domain, service 레이어 중에 있어야 하는데 service 레이어가 가장 적합하다고 판단

