### PR TITLE
Feature/46 feature 프로젝트 삭제

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/ProjectController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/ProjectController.java
@@ -17,10 +17,18 @@ public class ProjectController {
     @Autowired
     private ProjectServiceImpl projectService;
 
-    @PostMapping("/projects")
+    @PostMapping("/admins/projects")
     public BaseResponse<ProjectResponse.ProjectDto> resisterProjects(@RequestBody ProjectRequest.ResisterDto request) {
         ProjectResponse.ProjectDto projectDto = projectService.registerProject(request);
         log.info("FlowSync - resisterProjects name : {}, register_at : {}, resister_id : {}", projectDto.getName(), projectDto.getRegAt(), projectDto.getResisterId());
         return BaseResponse.success(projectDto);
     }
+
+    @DeleteMapping("/admins/projects/{projectId}")
+    public BaseResponse<ProjectResponse.ProjectDto> deleteProjects(@PathVariable Long projectId) {
+        ProjectResponse.ProjectDto projectDto = projectService.deleteProject(projectId);
+        log.info("FlowSync - deleteProjects project_id : {}, ", projectId);
+        return BaseResponse.success(projectDto);
+    }
+
 }

--- a/module-domain/src/main/java/com/checkping/domain/project/Project.java
+++ b/module-domain/src/main/java/com/checkping/domain/project/Project.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @ToString
-@Builder
+@Builder(toBuilder = true)
 @RequiredArgsConstructor
 @AllArgsConstructor
 @Table(name="project")
@@ -20,7 +20,7 @@ public class Project extends BaseEntity {
     name : 프로젝트 이름
     description : 프로젝트 설명
     detail : 프로젝트 세부 설명
-    status : 프로젝트 상태 * IN_PROGRESS(진행중), PAUSED(일시 중단), COMPLETED(완료), DELETED(삭제)
+    status : 프로젝트 상태 * IN_PROGRESS(진행중), PAUSED(일시 중단), COMPLETED(완료)
     reg_at : 프로젝트 등록 일시
     update_at : 프로젝트 수정 일시
     close_at : 프로젝트 종료 일시
@@ -69,8 +69,7 @@ public class Project extends BaseEntity {
     public enum Status {
         IN_PROGRESS("진행중"),
         PAUSED("일시 중단"),
-        COMPLETED("완료"),
-        DELETED("삭제");
+        COMPLETED("완료");
 
         private final String description;
     }

--- a/module-service/src/main/java/com/checkping/dto/ProjectRequest.java
+++ b/module-service/src/main/java/com/checkping/dto/ProjectRequest.java
@@ -20,9 +20,10 @@ public class ProjectRequest {
         name : 프로젝트 이름
         description : 프로젝트 설명
         detail : 프로젝트 세부 설명
-        status : 프로젝트 상태 * IN_PROGRESS(진행중), PAUSED(일시 중단), COMPLETED(완료), DELETED(삭제)
+        status : 프로젝트 상태 * IN_PROGRESS(진행중), PAUSED(일시 중단), COMPLETED(완료)
         closeAt : 프로젝트 종료 일시
         resisterId : 등록자 아이디
+        deletedYn : 삭제여부
         */
 
         private String name;
@@ -42,6 +43,7 @@ public class ProjectRequest {
                     .regAt(LocalDateTime.now())
                     .closeAt(resisterDto.getCloseAt())
                     .resisterId(resisterDto.getResisterId())
+                    .deletedYn("N")
                     .build();
         }
     }

--- a/module-service/src/main/java/com/checkping/dto/ProjectResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/ProjectResponse.java
@@ -24,6 +24,7 @@ public class ProjectResponse {
         private LocalDateTime closeAt;
         private Long resisterId;
         private Long updaterId;
+        private String deletedYn;
 
         public static ProjectDto toDto(Project project) {
             ProjectDto projectDto = new ProjectDto();
@@ -37,6 +38,7 @@ public class ProjectResponse {
             projectDto.setCloseAt(project.getCloseAt());
             projectDto.setResisterId(project.getResisterId());
             projectDto.setUpdaterId(project.getUpdaterId());
+            projectDto.setDeletedYn(project.getDeletedYn());
             return projectDto;
         }
     }

--- a/module-service/src/main/java/com/checkping/service/project/ProjectService.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectService.java
@@ -5,4 +5,6 @@ import com.checkping.dto.ProjectResponse;
 
 public interface ProjectService {
     ProjectResponse.ProjectDto registerProject(ProjectRequest.ResisterDto request);
+
+    ProjectResponse.ProjectDto deleteProject(Long projectId);
 }

--- a/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
@@ -1,7 +1,7 @@
 package com.checkping.service.project;
 
 import com.checkping.common.enums.ErrorCode;
-import com.checkping.common.exception.CustomException;
+import com.checkping.common.exception.BaseException;
 import com.checkping.domain.project.Project;
 import com.checkping.dto.ProjectResponse;
 import com.checkping.infra.repository.project.ProjectRepository;
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Slf4j
 @Service
@@ -22,9 +24,25 @@ public class ProjectServiceImpl implements ProjectService {
     @Override
     public ProjectResponse.ProjectDto registerProject(ProjectRequest.ResisterDto request) {
         if(request == null) {
-            throw new CustomException(ErrorCode.BAD_REQUEST);
+            throw new BaseException(ErrorCode.BAD_REQUEST);
         }
         Project project = projectRepository.save(ProjectRequest.ResisterDto.toEntity(request));
         return ProjectResponse.ProjectDto.toDto(project);
+    }
+
+    @Override
+    public ProjectResponse.ProjectDto deleteProject(Long projectId) {
+        if(projectId == null) {
+            throw new BaseException(ErrorCode.BAD_REQUEST);
+        }
+
+        Project project = projectRepository.findById(projectId).orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND));
+
+        Project updatedProject = project.toBuilder()
+                .updateAt(LocalDateTime.now())
+                .deletedYn("Y")
+                .build();
+
+        return ProjectResponse.ProjectDto.toDto(projectRepository.save(updatedProject));
     }
 }

--- a/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
@@ -6,6 +6,8 @@ import com.checkping.domain.project.Project;
 import com.checkping.dto.ProjectResponse;
 import com.checkping.infra.repository.project.ProjectRepository;
 import com.checkping.dto.ProjectRequest;
+
+import io.micrometer.common.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,9 +25,10 @@ public class ProjectServiceImpl implements ProjectService {
 
     @Override
     public ProjectResponse.ProjectDto registerProject(ProjectRequest.ResisterDto request) {
-        if(request == null) {
+        if (StringUtils.isBlank(request.getName())) {
             throw new BaseException(ErrorCode.BAD_REQUEST);
         }
+
         Project project = projectRepository.save(ProjectRequest.ResisterDto.toEntity(request));
         return ProjectResponse.ProjectDto.toDto(project);
     }

--- a/module-service/src/test/java/com/checkping/service/ProjectServiceTests.java
+++ b/module-service/src/test/java/com/checkping/service/ProjectServiceTests.java
@@ -2,6 +2,7 @@ package com.checkping.service;
 
 import com.checkping.domain.project.Project;
 import com.checkping.dto.ProjectRequest;
+import com.checkping.dto.ProjectResponse;
 import com.checkping.infra.repository.project.ProjectRepository;
 import com.checkping.service.project.ProjectServiceImpl;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ public class ProjectServiceTests {
     private ProjectRepository projectRepository;
 
     @Test
-    public void init(){
+    public void resisterProject() {
 
         projectService.registerProject(
                 ProjectRequest.ResisterDto.builder()
@@ -39,4 +40,24 @@ public class ProjectServiceTests {
         projects.forEach(project -> System.out.println(project));
         System.out.println(projects.size());
     }
+
+    @Test
+    public void deleteProject() {
+        projectService.registerProject(
+                ProjectRequest.ResisterDto.builder()
+                        .name("이름")
+                        .description("설명")
+                        .detail("상세설명")
+                        .status(String.valueOf(Project.Status.IN_PROGRESS))
+                        .closeAt(LocalDate.parse("2025-12-30").atStartOfDay())
+                        .resisterId(49283L)
+                        .build());
+
+        Project project = projectRepository.findById(1L).get();
+        System.out.println("resisterProject : " + project);
+
+        ProjectResponse.ProjectDto projectDto = projectService.deleteProject(1L);
+        System.out.println("deleteProject : " + projectDto);
+    }
+
 }


### PR DESCRIPTION
# 🚀 Pull Request

프로젝트 삭제 기능 추가

## #️⃣ 연관된 이슈

#46 

## 📋 작업 내용

- Project
  - 삭제여부는 deleted_yn으로만 관리하도록 수정
  - 엔티티의 일부 값만을 변경할 수 있도록 toBuilder = true 옵션 추가
- ProjectRequest
  - 프로젝트 생성 시 deleted_yn의 기본값은 'N'이 되도록 수정
- ProjectResponse
  - response에서 삭제여부 값을 확인할 수 있도록 수정
- ProjectController
  - 기존 URI 수정 및 삭제 메서드 추가
- ProjectService, ProjectServiceImpl
  - CustomException이 deprecated 되어 BaseException으로 수정
  - 삭제 메서드 추가 (soft delete)
  