### PR TITLE
Feature/53 feature 업무 관리 게시글 단일 조회 기능

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
@@ -5,8 +5,8 @@ import com.checkping.dto.TaskBoardCommentRequest;
 import com.checkping.dto.TaskBoardCommentResponse;
 import com.checkping.dto.TaskBoardRequest;
 import com.checkping.dto.TaskBoardRequest.SearchCondition;
-import com.checkping.dto.TaskBoardResponse;
-import com.checkping.dto.TaskBoardResponse.TaskBoardDto;
+import com.checkping.dto.TaskBoardResponse.TaskBoardItemDto;
+import com.checkping.dto.TaskBoardResponse.TaskBoardListDto;
 import com.checkping.service.project.TaskBoardCommentService;
 import com.checkping.service.project.TaskBoardService;
 import java.util.List;
@@ -28,16 +28,16 @@ public class TaskBoardController {
     private final TaskBoardCommentService taskBoardCommentService;
 
     @PostMapping("/posts")
-    public BaseResponse<TaskBoardResponse.TaskBoardDto> register(
+    public BaseResponse<TaskBoardItemDto> register(
         @RequestBody TaskBoardRequest.RegisterDto request) {
 
-        TaskBoardResponse.TaskBoardDto taskBoardDto = taskBoardService.register(request);
+        TaskBoardItemDto taskBoardDto = taskBoardService.register(request);
 
         return BaseResponse.success(taskBoardDto);
     }
 
     @GetMapping("/posts")
-    public BaseResponse<List<TaskBoardDto>> getTaskBoardList(
+    public BaseResponse<List<TaskBoardListDto>> getTaskBoardList(
         @RequestParam(required = false) String boardCategory,
         @RequestParam(required = false) String boardStatus) {
 
@@ -46,9 +46,18 @@ public class TaskBoardController {
             boardStatus);
 
         // getTaskBoardList
-        List<TaskBoardDto> taskBoardDtoList = taskBoardService.getTaskBoardList(searchCondition);
+        List<TaskBoardListDto> taskBoardListDtoList = taskBoardService.getTaskBoardList(
+            searchCondition);
 
-        return BaseResponse.success(taskBoardDtoList);
+        return BaseResponse.success(taskBoardListDtoList);
+    }
+
+    @GetMapping("/posts/{postId}")
+    public BaseResponse<TaskBoardItemDto> getTaskBoard(@PathVariable Long postId) {
+
+        TaskBoardItemDto taskBoardItemDto = taskBoardService.getTaskBoardById(postId);
+
+        return BaseResponse.success(taskBoardItemDto);
     }
 
     @PostMapping("/post/{postId}/comment")

--- a/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
@@ -60,7 +60,7 @@ public class TaskBoardController {
         return BaseResponse.success(taskBoardItemDto);
     }
 
-    @PostMapping("/post/{postId}/comment")
+    @PostMapping("/posts/{postId}/comment")
     public BaseResponse<TaskBoardCommentResponse.TaskBoardCommentDto> registerComment(
         @PathVariable Long postId, @RequestBody TaskBoardCommentRequest.RegisterDto request) {
 

--- a/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
+++ b/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
@@ -26,7 +26,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
-@ToString
+@ToString(exclude = "commentList")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -87,6 +87,9 @@ public class TaskBoard extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private TaskBoard parent;
+
+    @OneToMany(mappedBy = "taskBoard", fetch = FetchType.LAZY)
+    private List<TaskBoardComment> commentList = new ArrayList<>();
 
     @Getter
     @RequiredArgsConstructor

--- a/module-domain/src/main/java/com/checkping/domain/board/TaskBoardComment.java
+++ b/module-domain/src/main/java/com/checkping/domain/board/TaskBoardComment.java
@@ -23,7 +23,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
-@ToString
+@ToString(exclude = "taskBoard")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/module-service/src/main/java/com/checkping/dto/TaskBoardCommentResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/TaskBoardCommentResponse.java
@@ -3,6 +3,8 @@ package com.checkping.dto;
 import com.checkping.domain.board.TaskBoardComment;
 import com.checkping.domain.board.TaskBoardComment.DeleteStatus;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +16,7 @@ public class TaskBoardCommentResponse {
     @Getter
     @ToString
     public static class TaskBoardCommentDto {
+
         private Long taskBoardCommentId;
         private String content;
         private LocalDateTime regAt;
@@ -27,13 +30,30 @@ public class TaskBoardCommentResponse {
          * @param taskBoardComment TaskBoardComment Entity
          * @return TaskBoardCommentDto
          */
-        public static TaskBoardCommentDto toDto (TaskBoardComment taskBoardComment) {
+        public static TaskBoardCommentDto toDto(TaskBoardComment taskBoardComment) {
             TaskBoardCommentDto dto = new TaskBoardCommentDto();
             dto.taskBoardCommentId = taskBoardComment.getId();
             dto.content = taskBoardComment.getContent();
             dto.regAt = taskBoardComment.getRegAt();
             dto.editAt = taskBoardComment.getEditAt();
             return dto;
+        }
+
+        /**
+         * TaskBoardComment 리스트를 TaskBoardCommentDto 리스트로 변환
+         *
+         * @param taskBoardCommentList TaskBoardComment 의 리스트
+         * @return TaskBoardCommentDto 리스트
+         */
+        public static List<TaskBoardCommentDto> toDtoList(
+            List<TaskBoardComment> taskBoardCommentList) {
+
+            // null check
+            if (taskBoardCommentList == null) {
+                return Collections.emptyList();
+            }
+
+            return taskBoardCommentList.stream().map(TaskBoardCommentDto::toDto).toList();
         }
 
     }

--- a/module-service/src/main/java/com/checkping/dto/TaskBoardResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/TaskBoardResponse.java
@@ -1,17 +1,22 @@
 package com.checkping.dto;
 
 import com.checkping.domain.board.TaskBoard;
+import com.checkping.dto.TaskBoardResponse.TaskBoardListDto;
 import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TaskBoardResponse {
 
     @Getter
     @Setter
     @ToString
-    public static class TaskBoardDto {
+    public static class TaskBoardListDto {
         /*
         id : 게시글 고유 ID
         number : 게시글 번호
@@ -35,8 +40,8 @@ public class TaskBoardResponse {
         private TaskBoard.BoardStatus boardStatus;
         private TaskBoard.DeleteStatus deletedYn;
 
-        public static TaskBoardDto toDto(TaskBoard taskBoard) {
-            TaskBoardDto boardDto = new TaskBoardDto();
+        public static TaskBoardListDto toDto(TaskBoard taskBoard) {
+            TaskBoardListDto boardDto = new TaskBoardListDto();
             boardDto.setId(taskBoard.getId());
             boardDto.setNumber(taskBoard.getNumber());
             boardDto.setTitle(taskBoard.getTitle());
@@ -46,6 +51,57 @@ public class TaskBoardResponse {
             boardDto.setApproverAt(taskBoard.getApproverAt());
             boardDto.setBoardCategory(taskBoard.getBoardCategory());
             boardDto.setBoardStatus(taskBoard.getBoardStatus());
+            return boardDto;
+        }
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class TaskBoardItemDto {
+
+        /*
+        id : 게시글 고유 ID
+        number : 게시글 번호
+        title : 게시글 제목
+        content : 게시글 본문 내용
+        regAt : 게시글 작성 일시
+        editAt : 게시글 마지막 수정 일시
+        approverAt : 게시글 승인 일시
+        boardCategory : 게시글 카테고리 (enum, String)
+        boardStatus : 게시글 상태 (enum, String)
+        deletedYn : 게시글 삭제 여부 ('Y' 또는 'N')
+        commentList : 게시글 댓글 리스트
+         */
+        private Long id;
+        private Integer number;
+        private String title;
+        private String content;
+        private LocalDateTime regAt;
+        private LocalDateTime editAt;
+        private LocalDateTime approverAt;
+        private TaskBoard.BoardCategory boardCategory;
+        private TaskBoard.BoardStatus boardStatus;
+        private TaskBoard.DeleteStatus deletedYn;
+        private List<TaskBoardCommentResponse.TaskBoardCommentDto> commentList;
+
+        public static TaskBoardResponse.TaskBoardItemDto toDto(TaskBoard taskBoard) {
+            TaskBoardResponse.TaskBoardItemDto boardDto = new TaskBoardResponse.TaskBoardItemDto();
+            boardDto.setId(taskBoard.getId());
+            boardDto.setNumber(taskBoard.getNumber());
+            boardDto.setTitle(taskBoard.getTitle());
+            boardDto.setContent(taskBoard.getContent());
+            boardDto.setRegAt(taskBoard.getRegAt());
+            boardDto.setEditAt(taskBoard.getEditAt());
+            boardDto.setApproverAt(taskBoard.getApproverAt());
+            boardDto.setBoardCategory(taskBoard.getBoardCategory());
+            boardDto.setBoardStatus(taskBoard.getBoardStatus());
+
+            // Entity -> Dto
+            List<TaskBoardCommentResponse.TaskBoardCommentDto> comments =
+                TaskBoardCommentResponse.TaskBoardCommentDto.toDtoList(taskBoard.getCommentList());
+            boardDto.setCommentList(comments);
+
             return boardDto;
         }
     }

--- a/module-service/src/main/java/com/checkping/service/project/TaskBoardService.java
+++ b/module-service/src/main/java/com/checkping/service/project/TaskBoardService.java
@@ -1,11 +1,12 @@
 package com.checkping.service.project;
 
 import com.checkping.dto.TaskBoardRequest;
-import com.checkping.dto.TaskBoardResponse;
-import com.checkping.dto.TaskBoardResponse.TaskBoardDto;
+import com.checkping.dto.TaskBoardResponse.TaskBoardItemDto;
+import com.checkping.dto.TaskBoardResponse.TaskBoardListDto;
 import java.util.List;
 
 public interface TaskBoardService {
-    TaskBoardResponse.TaskBoardDto register(TaskBoardRequest.RegisterDto request);
-    List<TaskBoardDto> getTaskBoardList(TaskBoardRequest.SearchCondition searchCondition);
+    TaskBoardItemDto register(TaskBoardRequest.RegisterDto request);
+    List<TaskBoardListDto> getTaskBoardList(TaskBoardRequest.SearchCondition searchCondition);
+    TaskBoardItemDto getTaskBoardById(Long taskBoardId);
 }

--- a/module-service/src/main/java/com/checkping/service/project/TaskBoardServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/TaskBoardServiceImpl.java
@@ -3,8 +3,9 @@ package com.checkping.service.project;
 import com.checkping.domain.board.TaskBoard;
 import com.checkping.dto.TaskBoardRequest;
 import com.checkping.dto.TaskBoardRequest.SearchCondition;
-import com.checkping.dto.TaskBoardResponse;
-import com.checkping.dto.TaskBoardResponse.TaskBoardDto;
+import com.checkping.dto.TaskBoardResponse.TaskBoardItemDto;
+import com.checkping.dto.TaskBoardResponse.TaskBoardListDto;
+import com.checkping.exception.project.TaskBoardNotFoundEntityException;
 import com.checkping.infra.repository.project.taskboard.TaskBoardReader;
 import com.checkping.infra.repository.project.taskboard.TaskBoardStore;
 import java.util.List;
@@ -25,7 +26,7 @@ public class TaskBoardServiceImpl implements TaskBoardService {
      * @return 생성한 TaskBoard 의 Dto
      */
     @Override
-    public TaskBoardResponse.TaskBoardDto register(TaskBoardRequest.RegisterDto request) {
+    public TaskBoardItemDto register(TaskBoardRequest.RegisterDto request) {
 
         // dto -> entity
         TaskBoard initTaskBoard = TaskBoardRequest.RegisterDto.toEntity(request);
@@ -35,24 +36,41 @@ public class TaskBoardServiceImpl implements TaskBoardService {
         TaskBoard taskBoard = taskBoardStore.store(initTaskBoard);
 
         // entity -> dto
-        return TaskBoardResponse.TaskBoardDto.toDto(taskBoard);
+        return TaskBoardItemDto.toDto(taskBoard);
     }
 
     /**
      * TaskBoard 조회 하기 (게시글 유형, 게시글 상태 별 필터링)
      *
      * @param searchCondition RequestParam 에서 받아오는 String 을 관리하는 타입
-     * @return 조회한 TaskBoardDto 의 리스트
+     * @return 조회한 TaskBoardListDto 의 리스트
      */
     @Override
-    public List<TaskBoardDto> getTaskBoardList(SearchCondition searchCondition) {
+    public List<TaskBoardListDto> getTaskBoardList(SearchCondition searchCondition) {
 
         // 조회
         List<TaskBoard> taskBoardList = taskBoardReader.getTaskBoard(
             searchCondition.getBoardCategory(),
             searchCondition.getBoardStatus());
 
-        // TaskBoard -> TaskBoardDto
-        return taskBoardList.stream().map(TaskBoardDto::toDto).toList();
+        // TaskBoard -> TaskBoardListDto
+        return taskBoardList.stream().map(TaskBoardListDto::toDto).toList();
+    }
+
+    /**
+     * 업무 관리 게시글 서비스 - 상세 조회
+     *
+     * @param taskBoardId 업무 관리 게시글 ID
+     * @return TaskBoardListDto
+     */
+    @Override
+    public TaskBoardItemDto getTaskBoardById(Long taskBoardId) {
+
+        // find TaskBoard Entity
+        TaskBoard taskBoard = taskBoardReader.getTaskBoardById(taskBoardId).orElseThrow(
+            TaskBoardNotFoundEntityException::new);
+
+        // Entity -> Dto
+        return TaskBoardItemDto.toDto(taskBoard);
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

**[업무 관리 게시글 단일 조회 기능]**

## #️⃣ 연관된 이슈

- #16 
- #53 

## 📋 작업 내용

- TaskBoard, TaskBoardComment 엔티티 간의 연관 관계 맵핑
- TaskBoard 엔티티의 List<TaskBoardComment>를 List<TaskBoardCommentDto> 로 변경하는 기능 구현
- TaskBoard 조회 시 결과 Dto 를 목록 조회와 상세 조회로 구분하도록 구현
- api 오타 수정
  - /post/{postId}/comment -> /posts/{postId}/comment

### 작업 결과
```json
{
  "code": 200,
  "result": "SUCCESS",
  "data": {
    "id": 1,
    "number": 1,
    "title": "테스트 제목 2",
    "content": "지금의 제목은 이렇게 들어갑니다 1",
    "regAt": "2025-01-11T22:45:23.408081",
    "editAt": "2025-01-11T22:45:23.408081",
    "approverAt": null,
    "boardCategory": "QUESTION",
    "boardStatus": "PROGRESS",
    "deletedYn": null,
    "commentList": [
      {
        "taskBoardCommentId": 1,
        "content": "댓글 테스트 222",
        "regAt": "2025-01-11T22:45:39.203833",
        "editAt": "2025-01-11T22:45:39.203833",
        "deleteStatus": null
      },
      {
        "taskBoardCommentId": 2,
        "content": "댓글 테스트 111",
        "regAt": "2025-01-11T22:45:43.277761",
        "editAt": "2025-01-11T22:45:43.277761",
        "deleteStatus": null
      }
    ]
  }
}
```
