### PR TITLE
Feature/55 feature 업무 관리 게시글 삭제 기능

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
@@ -61,7 +61,7 @@ public class TaskBoardController {
         return BaseResponse.success(taskBoardItemDto);
     }
 
-    @PostMapping("/posts/{postId}/comment")
+    @PostMapping("/posts/{postId}/comments")
     public BaseResponse<TaskBoardCommentResponse.TaskBoardCommentDto> registerComment(
         @PathVariable Long postId, @RequestBody TaskBoardCommentRequest.RegisterDto request) {
 

--- a/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -79,5 +80,16 @@ public class TaskBoardController {
             postId, commentId);
 
         return BaseResponse.success(deletedCommentDto);
+    }
+
+    @PutMapping("/posts/{postId}/comments/{commentId}")
+    public BaseResponse<TaskBoardCommentResponse.TaskBoardCommentDto> updateComment(
+        @PathVariable Long postId, @PathVariable Long commentId,
+        @RequestBody TaskBoardCommentRequest.UpdateDto request) {
+
+        TaskBoardCommentResponse.TaskBoardCommentDto updatedCommentDto = taskBoardCommentService.update(
+            postId, commentId, request);
+
+        return BaseResponse.success(updatedCommentDto);
     }
 }

--- a/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
@@ -5,6 +5,7 @@ import com.checkping.dto.TaskBoardCommentRequest;
 import com.checkping.dto.TaskBoardCommentResponse;
 import com.checkping.dto.TaskBoardRequest;
 import com.checkping.dto.TaskBoardRequest.SearchCondition;
+import com.checkping.dto.TaskBoardResponse;
 import com.checkping.dto.TaskBoardResponse.TaskBoardItemDto;
 import com.checkping.dto.TaskBoardResponse.TaskBoardListDto;
 import com.checkping.service.project.TaskBoardCommentService;
@@ -60,6 +61,15 @@ public class TaskBoardController {
         TaskBoardItemDto taskBoardItemDto = taskBoardService.getTaskBoardById(postId);
 
         return BaseResponse.success(taskBoardItemDto);
+    }
+
+    @DeleteMapping("/posts/{postId}")
+    public BaseResponse<TaskBoardResponse.TaskBoardListDto> deleteSoftTaskBoard(
+        @PathVariable Long postId) {
+
+        TaskBoardResponse.TaskBoardListDto deletedBoardDto = taskBoardService.deleteSoft(postId);
+
+        return BaseResponse.success(deletedBoardDto);
     }
 
     @PostMapping("/posts/{postId}/comments")

--- a/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
@@ -5,8 +5,8 @@ import com.checkping.dto.TaskBoardCommentRequest;
 import com.checkping.dto.TaskBoardCommentResponse;
 import com.checkping.dto.TaskBoardRequest;
 import com.checkping.dto.TaskBoardRequest.SearchCondition;
-import com.checkping.dto.TaskBoardResponse;
-import com.checkping.dto.TaskBoardResponse.TaskBoardDto;
+import com.checkping.dto.TaskBoardResponse.TaskBoardItemDto;
+import com.checkping.dto.TaskBoardResponse.TaskBoardListDto;
 import com.checkping.service.project.TaskBoardCommentService;
 import com.checkping.service.project.TaskBoardService;
 import java.util.List;
@@ -28,16 +28,16 @@ public class TaskBoardController {
     private final TaskBoardCommentService taskBoardCommentService;
 
     @PostMapping("/posts")
-    public BaseResponse<TaskBoardResponse.TaskBoardDto> register(
+    public BaseResponse<TaskBoardItemDto> register(
         @RequestBody TaskBoardRequest.RegisterDto request) {
 
-        TaskBoardResponse.TaskBoardDto taskBoardDto = taskBoardService.register(request);
+        TaskBoardItemDto taskBoardDto = taskBoardService.register(request);
 
         return BaseResponse.success(taskBoardDto);
     }
 
     @GetMapping("/posts")
-    public BaseResponse<List<TaskBoardDto>> getTaskBoardList(
+    public BaseResponse<List<TaskBoardListDto>> getTaskBoardList(
         @RequestParam(required = false) String boardCategory,
         @RequestParam(required = false) String boardStatus) {
 
@@ -46,9 +46,18 @@ public class TaskBoardController {
             boardStatus);
 
         // getTaskBoardList
-        List<TaskBoardDto> taskBoardDtoList = taskBoardService.getTaskBoardList(searchCondition);
+        List<TaskBoardListDto> taskBoardListDtoList = taskBoardService.getTaskBoardList(
+            searchCondition);
 
-        return BaseResponse.success(taskBoardDtoList);
+        return BaseResponse.success(taskBoardListDtoList);
+    }
+
+    @GetMapping("/posts/{postId}")
+    public BaseResponse<TaskBoardItemDto> getTaskBoard(@PathVariable Long postId) {
+
+        TaskBoardItemDto taskBoardItemDto = taskBoardService.getTaskBoardById(postId);
+
+        return BaseResponse.success(taskBoardItemDto);
     }
 
     @PostMapping("/post/{postId}/comment")

--- a/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
@@ -60,7 +60,7 @@ public class TaskBoardController {
         return BaseResponse.success(taskBoardItemDto);
     }
 
-    @PostMapping("/post/{postId}/comment")
+    @PostMapping("/posts/{postId}/comment")
     public BaseResponse<TaskBoardCommentResponse.TaskBoardCommentDto> registerComment(
         @PathVariable Long postId, @RequestBody TaskBoardCommentRequest.RegisterDto request) {
 

--- a/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/TaskBoardController.java
@@ -12,6 +12,7 @@ import com.checkping.service.project.TaskBoardService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -68,5 +69,15 @@ public class TaskBoardController {
             postId, request);
 
         return BaseResponse.success(taskBoardCommentDto);
+    }
+
+    @DeleteMapping("/posts/{postId}/comments/{commentId}")
+    public BaseResponse<TaskBoardCommentResponse.TaskBoardCommentDto> deleteSoft(
+        @PathVariable Long postId, @PathVariable Long commentId) {
+
+        TaskBoardCommentResponse.TaskBoardCommentDto deletedCommentDto = taskBoardCommentService.deleteSoft(
+            postId, commentId);
+
+        return BaseResponse.success(deletedCommentDto);
     }
 }

--- a/module-api/src/main/java/com/checkping/api/exceptionhandler/GlobalExceptionHandler.java
+++ b/module-api/src/main/java/com/checkping/api/exceptionhandler/GlobalExceptionHandler.java
@@ -1,21 +1,32 @@
 package com.checkping.api.exceptionhandler;
 
 import com.checkping.common.enums.ErrorCode;
+import com.checkping.common.exception.BaseException;
 import com.checkping.common.exception.CustomException;
 import com.checkping.common.response.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
     public BaseResponse handlerCustomException(CustomException e) {
+        log.error(e.getMessage(), e);
+        return BaseResponse.fail(e.getErrorCode());
+    }
+
+    @ExceptionHandler(BaseException.class)
+    public BaseResponse handlerBaseException(BaseException e) {
+        log.error(e.getMessage(), e);
         return BaseResponse.fail(e.getErrorCode());
     }
 
     @ExceptionHandler(Exception.class)
     public BaseResponse handlerException(Exception e) {
+        log.error(e.getMessage(), e);
         return BaseResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR);
     }
 }

--- a/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
+++ b/module-domain/src/main/java/com/checkping/domain/board/TaskBoard.java
@@ -26,7 +26,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
-@ToString
+@ToString(exclude = "commentList")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -87,6 +87,9 @@ public class TaskBoard extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private TaskBoard parent;
+
+    @OneToMany(mappedBy = "taskBoard", fetch = FetchType.LAZY)
+    private List<TaskBoardComment> commentList = new ArrayList<>();
 
     @Getter
     @RequiredArgsConstructor

--- a/module-domain/src/main/java/com/checkping/domain/board/TaskBoardComment.java
+++ b/module-domain/src/main/java/com/checkping/domain/board/TaskBoardComment.java
@@ -82,4 +82,9 @@ public class TaskBoardComment extends BaseEntity {
     public void activate() {
         this.deletedYn = DeleteStatus.N;
     }
+
+    // update
+    public void update(String content) {
+        this.content = content;
+    }
 }

--- a/module-domain/src/main/java/com/checkping/domain/board/TaskBoardComment.java
+++ b/module-domain/src/main/java/com/checkping/domain/board/TaskBoardComment.java
@@ -23,7 +23,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
-@ToString
+@ToString(exclude = "taskBoard")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/taskboard/TaskBoardStore.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/taskboard/TaskBoardStore.java
@@ -5,4 +5,6 @@ import com.checkping.domain.board.TaskBoard;
 public interface TaskBoardStore {
 
     TaskBoard store(TaskBoard taskBoard);
+
+    void deleteHard(TaskBoard taskBoard);
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/taskboard/TaskBoardStoreImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/taskboard/TaskBoardStoreImpl.java
@@ -13,4 +13,14 @@ public class TaskBoardStoreImpl implements TaskBoardStore {
     public TaskBoard store(TaskBoard taskBoard) {
         return taskBoardRepository.save(taskBoard);
     }
+
+    /**
+     * HARD DELETE - TaskBoard
+     *
+     * @param taskBoard 삭제할 TaskBoard 엔티티
+     */
+    @Override
+    public void deleteHard(TaskBoard taskBoard) {
+        taskBoardRepository.delete(taskBoard);
+    }
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/taskboardcomment/TaskBoardCommentReader.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/taskboardcomment/TaskBoardCommentReader.java
@@ -1,0 +1,11 @@
+package com.checkping.infra.repository.project.taskboardcomment;
+
+import com.checkping.domain.board.TaskBoardComment;
+import java.util.Optional;
+
+public interface TaskBoardCommentReader {
+
+    Optional<TaskBoardComment> getByTaskBoardCommentId(Long taskBoardCommentId);
+
+    boolean checkCommentContaining(Long taskBoardId, Long taskBoardCommentId);
+}

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/taskboardcomment/TaskBoardCommentReaderImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/taskboardcomment/TaskBoardCommentReaderImpl.java
@@ -1,0 +1,30 @@
+package com.checkping.infra.repository.project.taskboardcomment;
+
+import com.checkping.domain.board.TaskBoardComment;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TaskBoardCommentReaderImpl implements TaskBoardCommentReader {
+
+    private final TaskBoardCommentRepository taskBoardCommentRepository;
+
+    @Override
+    public Optional<TaskBoardComment> getByTaskBoardCommentId(Long taskBoardCommentId) {
+        return taskBoardCommentRepository.findById(taskBoardCommentId);
+    }
+
+    /**
+     * 업무 관리 게시글 댓글의 게시글 포함 여부
+     *
+     * @param taskBoardId 업무 관리 게시글 ID
+     * @param taskBoardCommentId 업무 관리 게시글 댓글 ID
+     * @return 업무 관리 게시글 댓글의 해당 업무 관리 게시글 포함 여부
+     */
+    @Override
+    public boolean checkCommentContaining(Long taskBoardId, Long taskBoardCommentId) {
+        return taskBoardCommentRepository.existsByIdAndTaskBoardId(taskBoardId, taskBoardCommentId);
+    }
+}

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/taskboardcomment/TaskBoardCommentRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/taskboardcomment/TaskBoardCommentRepository.java
@@ -1,10 +1,12 @@
 package com.checkping.infra.repository.project.taskboardcomment;
 
 import com.checkping.domain.board.TaskBoardComment;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TaskBoardCommentRepository extends JpaRepository<TaskBoardComment, Long> {
-
+    Optional<TaskBoardComment> findById(Long id);
+    boolean existsByIdAndTaskBoardId(Long id, Long taskBoardId);
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/taskboardcomment/TaskBoardCommentStore.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/taskboardcomment/TaskBoardCommentStore.java
@@ -5,4 +5,6 @@ import com.checkping.domain.board.TaskBoardComment;
 public interface TaskBoardCommentStore {
 
     TaskBoardComment store(TaskBoardComment taskBoardComment);
+
+    void deleteHard(TaskBoardComment taskBoardComment);
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/taskboardcomment/TaskBoardCommentStoreImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/taskboardcomment/TaskBoardCommentStoreImpl.java
@@ -20,4 +20,9 @@ public class TaskBoardCommentStoreImpl implements TaskBoardCommentStore {
     public TaskBoardComment store(TaskBoardComment taskBoardComment) {
         return taskBoardCommentRepository.save(taskBoardComment);
     }
+
+    @Override
+    public void deleteHard(TaskBoardComment taskBoardComment) {
+        taskBoardCommentRepository.delete(taskBoardComment);
+    }
 }

--- a/module-service/src/main/java/com/checkping/dto/TaskBoardCommentRequest.java
+++ b/module-service/src/main/java/com/checkping/dto/TaskBoardCommentRequest.java
@@ -33,4 +33,13 @@ public class TaskBoardCommentRequest {
                 .build();
         }
     }
+
+    @Getter
+    @ToString
+    public static class UpdateDto {
+        /*
+        content : 댓글 내용
+         */
+        private String content;
+    }
 }

--- a/module-service/src/main/java/com/checkping/dto/TaskBoardCommentResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/TaskBoardCommentResponse.java
@@ -3,6 +3,8 @@ package com.checkping.dto;
 import com.checkping.domain.board.TaskBoardComment;
 import com.checkping.domain.board.TaskBoardComment.DeleteStatus;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +16,7 @@ public class TaskBoardCommentResponse {
     @Getter
     @ToString
     public static class TaskBoardCommentDto {
+
         private Long taskBoardCommentId;
         private String content;
         private LocalDateTime regAt;
@@ -27,13 +30,30 @@ public class TaskBoardCommentResponse {
          * @param taskBoardComment TaskBoardComment Entity
          * @return TaskBoardCommentDto
          */
-        public static TaskBoardCommentDto toDto (TaskBoardComment taskBoardComment) {
+        public static TaskBoardCommentDto toDto(TaskBoardComment taskBoardComment) {
             TaskBoardCommentDto dto = new TaskBoardCommentDto();
             dto.taskBoardCommentId = taskBoardComment.getId();
             dto.content = taskBoardComment.getContent();
             dto.regAt = taskBoardComment.getRegAt();
             dto.editAt = taskBoardComment.getEditAt();
             return dto;
+        }
+
+        /**
+         * TaskBoardComment 리스트를 TaskBoardCommentDto 리스트로 변환
+         *
+         * @param taskBoardCommentList TaskBoardComment 의 리스트
+         * @return TaskBoardCommentDto 리스트
+         */
+        public static List<TaskBoardCommentDto> toDtoList(
+            List<TaskBoardComment> taskBoardCommentList) {
+
+            // null check
+            if (taskBoardCommentList == null) {
+                return Collections.emptyList();
+            }
+
+            return taskBoardCommentList.stream().map(TaskBoardCommentDto::toDto).toList();
         }
 
     }

--- a/module-service/src/main/java/com/checkping/dto/TaskBoardCommentResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/TaskBoardCommentResponse.java
@@ -21,7 +21,7 @@ public class TaskBoardCommentResponse {
         private String content;
         private LocalDateTime regAt;
         private LocalDateTime editAt;
-        private DeleteStatus deleteStatus;
+        private DeleteStatus deletedYn;
 
 
         /**
@@ -36,6 +36,7 @@ public class TaskBoardCommentResponse {
             dto.content = taskBoardComment.getContent();
             dto.regAt = taskBoardComment.getRegAt();
             dto.editAt = taskBoardComment.getEditAt();
+            dto.deletedYn = taskBoardComment.getDeletedYn();
             return dto;
         }
 

--- a/module-service/src/main/java/com/checkping/dto/TaskBoardResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/TaskBoardResponse.java
@@ -51,6 +51,7 @@ public class TaskBoardResponse {
             boardDto.setApproverAt(taskBoard.getApproverAt());
             boardDto.setBoardCategory(taskBoard.getBoardCategory());
             boardDto.setBoardStatus(taskBoard.getBoardStatus());
+            boardDto.setDeletedYn(taskBoard.getDeletedYn());
             return boardDto;
         }
     }
@@ -96,6 +97,7 @@ public class TaskBoardResponse {
             boardDto.setApproverAt(taskBoard.getApproverAt());
             boardDto.setBoardCategory(taskBoard.getBoardCategory());
             boardDto.setBoardStatus(taskBoard.getBoardStatus());
+            boardDto.setDeletedYn(taskBoard.getDeletedYn());
 
             // Entity -> Dto
             List<TaskBoardCommentResponse.TaskBoardCommentDto> comments =

--- a/module-service/src/main/java/com/checkping/dto/TaskBoardResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/TaskBoardResponse.java
@@ -1,17 +1,22 @@
 package com.checkping.dto;
 
 import com.checkping.domain.board.TaskBoard;
+import com.checkping.dto.TaskBoardResponse.TaskBoardListDto;
 import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TaskBoardResponse {
 
     @Getter
     @Setter
     @ToString
-    public static class TaskBoardDto {
+    public static class TaskBoardListDto {
         /*
         id : 게시글 고유 ID
         number : 게시글 번호
@@ -35,8 +40,8 @@ public class TaskBoardResponse {
         private TaskBoard.BoardStatus boardStatus;
         private TaskBoard.DeleteStatus deletedYn;
 
-        public static TaskBoardDto toDto(TaskBoard taskBoard) {
-            TaskBoardDto boardDto = new TaskBoardDto();
+        public static TaskBoardListDto toDto(TaskBoard taskBoard) {
+            TaskBoardListDto boardDto = new TaskBoardListDto();
             boardDto.setId(taskBoard.getId());
             boardDto.setNumber(taskBoard.getNumber());
             boardDto.setTitle(taskBoard.getTitle());
@@ -46,6 +51,57 @@ public class TaskBoardResponse {
             boardDto.setApproverAt(taskBoard.getApproverAt());
             boardDto.setBoardCategory(taskBoard.getBoardCategory());
             boardDto.setBoardStatus(taskBoard.getBoardStatus());
+            return boardDto;
+        }
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class TaskBoardItemDto {
+
+        /*
+        id : 게시글 고유 ID
+        number : 게시글 번호
+        title : 게시글 제목
+        content : 게시글 본문 내용
+        regAt : 게시글 작성 일시
+        editAt : 게시글 마지막 수정 일시
+        approverAt : 게시글 승인 일시
+        boardCategory : 게시글 카테고리 (enum, String)
+        boardStatus : 게시글 상태 (enum, String)
+        deletedYn : 게시글 삭제 여부 ('Y' 또는 'N')
+        commentList : 게시글 댓글 리스트
+         */
+        private Long id;
+        private Integer number;
+        private String title;
+        private String content;
+        private LocalDateTime regAt;
+        private LocalDateTime editAt;
+        private LocalDateTime approverAt;
+        private TaskBoard.BoardCategory boardCategory;
+        private TaskBoard.BoardStatus boardStatus;
+        private TaskBoard.DeleteStatus deletedYn;
+        private List<TaskBoardCommentResponse.TaskBoardCommentDto> commentList;
+
+        public static TaskBoardResponse.TaskBoardItemDto toDto(TaskBoard taskBoard) {
+            TaskBoardResponse.TaskBoardItemDto boardDto = new TaskBoardResponse.TaskBoardItemDto();
+            boardDto.setId(taskBoard.getId());
+            boardDto.setNumber(taskBoard.getNumber());
+            boardDto.setTitle(taskBoard.getTitle());
+            boardDto.setContent(taskBoard.getContent());
+            boardDto.setRegAt(taskBoard.getRegAt());
+            boardDto.setEditAt(taskBoard.getEditAt());
+            boardDto.setApproverAt(taskBoard.getApproverAt());
+            boardDto.setBoardCategory(taskBoard.getBoardCategory());
+            boardDto.setBoardStatus(taskBoard.getBoardStatus());
+
+            // Entity -> Dto
+            List<TaskBoardCommentResponse.TaskBoardCommentDto> comments =
+                TaskBoardCommentResponse.TaskBoardCommentDto.toDtoList(taskBoard.getCommentList());
+            boardDto.setCommentList(comments);
+
             return boardDto;
         }
     }

--- a/module-service/src/main/java/com/checkping/exception/project/TaskBoardCommentMisMatchEntityException.java
+++ b/module-service/src/main/java/com/checkping/exception/project/TaskBoardCommentMisMatchEntityException.java
@@ -1,0 +1,10 @@
+package com.checkping.exception.project;
+
+import com.checkping.common.enums.ErrorCode;
+
+public class TaskBoardCommentMisMatchEntityException extends TaskBoardException {
+
+    public TaskBoardCommentMisMatchEntityException() {
+        super("업무 관리 게시글에 속하지 않은 댓글입니다.", ErrorCode.BAD_REQUEST);
+    }
+}

--- a/module-service/src/main/java/com/checkping/exception/project/TaskBoardCommentNotFoundEntityException.java
+++ b/module-service/src/main/java/com/checkping/exception/project/TaskBoardCommentNotFoundEntityException.java
@@ -1,0 +1,10 @@
+package com.checkping.exception.project;
+
+import com.checkping.common.enums.ErrorCode;
+
+public class TaskBoardCommentNotFoundEntityException extends TaskBoardException {
+
+    public TaskBoardCommentNotFoundEntityException() {
+        super("업무 관리 게시글 댓글을 찾을 수 없습니다.", ErrorCode.NOT_FOUND);
+    }
+}

--- a/module-service/src/main/java/com/checkping/service/project/TaskBoardCommentService.java
+++ b/module-service/src/main/java/com/checkping/service/project/TaskBoardCommentService.java
@@ -7,4 +7,10 @@ public interface TaskBoardCommentService {
 
     TaskBoardCommentResponse.TaskBoardCommentDto register(
         Long taskBoardId, RegisterDto request);
+
+    TaskBoardCommentResponse.TaskBoardCommentDto deleteSoft(Long taskBoardId,
+        Long taskBoardCommentId);
+
+    TaskBoardCommentResponse.TaskBoardCommentDto deleteHard(Long taskBoardId,
+        Long taskBoardCommentId);
 }

--- a/module-service/src/main/java/com/checkping/service/project/TaskBoardCommentService.java
+++ b/module-service/src/main/java/com/checkping/service/project/TaskBoardCommentService.java
@@ -1,5 +1,6 @@
 package com.checkping.service.project;
 
+import com.checkping.dto.TaskBoardCommentRequest;
 import com.checkping.dto.TaskBoardCommentRequest.RegisterDto;
 import com.checkping.dto.TaskBoardCommentResponse;
 
@@ -13,4 +14,7 @@ public interface TaskBoardCommentService {
 
     TaskBoardCommentResponse.TaskBoardCommentDto deleteHard(Long taskBoardId,
         Long taskBoardCommentId);
+
+    TaskBoardCommentResponse.TaskBoardCommentDto update(Long taskBoardId, Long taskBoardCommentId,
+        TaskBoardCommentRequest.UpdateDto request);
 }

--- a/module-service/src/main/java/com/checkping/service/project/TaskBoardCommentServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/TaskBoardCommentServiceImpl.java
@@ -5,8 +5,12 @@ import com.checkping.domain.board.TaskBoardComment;
 import com.checkping.dto.TaskBoardCommentRequest;
 import com.checkping.dto.TaskBoardCommentRequest.RegisterDto;
 import com.checkping.dto.TaskBoardCommentResponse;
+import com.checkping.dto.TaskBoardCommentResponse.TaskBoardCommentDto;
+import com.checkping.exception.project.TaskBoardCommentMisMatchEntityException;
+import com.checkping.exception.project.TaskBoardCommentNotFoundEntityException;
 import com.checkping.exception.project.TaskBoardNotFoundEntityException;
 import com.checkping.infra.repository.project.taskboard.TaskBoardReader;
+import com.checkping.infra.repository.project.taskboardcomment.TaskBoardCommentReader;
 import com.checkping.infra.repository.project.taskboardcomment.TaskBoardCommentStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +21,7 @@ public class TaskBoardCommentServiceImpl implements TaskBoardCommentService {
 
     private final TaskBoardReader taskBoardReader;
     private final TaskBoardCommentStore taskBoardCommentStore;
+    private final TaskBoardCommentReader taskBoardCommentReader;
 
     /**
      * 업무 관리 게시글 서비스 - 등록 기능
@@ -43,5 +48,64 @@ public class TaskBoardCommentServiceImpl implements TaskBoardCommentService {
 
         // Entity -> Dto
         return TaskBoardCommentResponse.TaskBoardCommentDto.toDto(taskBoardComment);
+    }
+
+    /**
+     * 업무 관리 게시글 댓글 서비스 - 댓글 소프트 삭제
+     *
+     * @param taskBoardId 업무 관리 게시글 ID
+     * @param taskBoardCommentId 업무 관리 게시글 댓글 ID
+     * @return 삭제 상태인 TaskBoardComment
+     */
+    @Override
+    public TaskBoardCommentDto deleteSoft(Long taskBoardId, Long taskBoardCommentId) {
+
+        // 업무 관리 게시글에 속한 댓글인지 확인
+        boolean isContaining = taskBoardCommentReader.checkCommentContaining(taskBoardId, taskBoardCommentId);
+        if (!isContaining) {
+            throw new TaskBoardCommentMisMatchEntityException();
+        }
+
+        // find TaskBoardComment Entity
+        TaskBoardComment initComment = taskBoardCommentReader.getByTaskBoardCommentId(
+            taskBoardCommentId).orElseThrow(
+            TaskBoardCommentNotFoundEntityException::new);
+
+        // soft delete
+        initComment.deactivate();
+
+        // save
+        TaskBoardComment deletedTaskBoardComment = taskBoardCommentStore.store(initComment);
+
+        // Entity -> Dto
+        return TaskBoardCommentResponse.TaskBoardCommentDto.toDto(deletedTaskBoardComment);
+    }
+
+    /**
+     * 업무 관리 게시글 댓글 서비스 - 댓글 하드 삭제
+     *
+     * @param taskBoardId 업무 관리 게시글 ID
+     * @param taskBoardCommentId 업무 관리 게시글 댓글 ID
+     * @return 삭제된 TaskBoardComment
+     */
+    @Override
+    public TaskBoardCommentDto deleteHard(Long taskBoardId, Long taskBoardCommentId) {
+
+        // 업무 관리 게시글에 속한 댓글인지 확인
+        boolean isContaining = taskBoardCommentReader.checkCommentContaining(taskBoardId, taskBoardCommentId);
+        if (!isContaining) {
+            throw new TaskBoardCommentMisMatchEntityException();
+        }
+
+        // find TaskBoardComment Entity
+        TaskBoardComment initComment = taskBoardCommentReader.getByTaskBoardCommentId(
+            taskBoardCommentId).orElseThrow(
+            TaskBoardCommentNotFoundEntityException::new);
+
+        // HARD DELETE
+        taskBoardCommentStore.deleteHard(initComment);
+
+        // Entity -> Dto
+        return TaskBoardCommentResponse.TaskBoardCommentDto.toDto(initComment);
     }
 }

--- a/module-service/src/main/java/com/checkping/service/project/TaskBoardCommentServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/TaskBoardCommentServiceImpl.java
@@ -4,6 +4,7 @@ import com.checkping.domain.board.TaskBoard;
 import com.checkping.domain.board.TaskBoardComment;
 import com.checkping.dto.TaskBoardCommentRequest;
 import com.checkping.dto.TaskBoardCommentRequest.RegisterDto;
+import com.checkping.dto.TaskBoardCommentRequest.UpdateDto;
 import com.checkping.dto.TaskBoardCommentResponse;
 import com.checkping.dto.TaskBoardCommentResponse.TaskBoardCommentDto;
 import com.checkping.exception.project.TaskBoardCommentMisMatchEntityException;
@@ -53,7 +54,7 @@ public class TaskBoardCommentServiceImpl implements TaskBoardCommentService {
     /**
      * 업무 관리 게시글 댓글 서비스 - 댓글 소프트 삭제
      *
-     * @param taskBoardId 업무 관리 게시글 ID
+     * @param taskBoardId        업무 관리 게시글 ID
      * @param taskBoardCommentId 업무 관리 게시글 댓글 ID
      * @return 삭제 상태인 TaskBoardComment
      */
@@ -61,7 +62,8 @@ public class TaskBoardCommentServiceImpl implements TaskBoardCommentService {
     public TaskBoardCommentDto deleteSoft(Long taskBoardId, Long taskBoardCommentId) {
 
         // 업무 관리 게시글에 속한 댓글인지 확인
-        boolean isContaining = taskBoardCommentReader.checkCommentContaining(taskBoardId, taskBoardCommentId);
+        boolean isContaining = taskBoardCommentReader.checkCommentContaining(taskBoardId,
+            taskBoardCommentId);
         if (!isContaining) {
             throw new TaskBoardCommentMisMatchEntityException();
         }
@@ -84,7 +86,7 @@ public class TaskBoardCommentServiceImpl implements TaskBoardCommentService {
     /**
      * 업무 관리 게시글 댓글 서비스 - 댓글 하드 삭제
      *
-     * @param taskBoardId 업무 관리 게시글 ID
+     * @param taskBoardId        업무 관리 게시글 ID
      * @param taskBoardCommentId 업무 관리 게시글 댓글 ID
      * @return 삭제된 TaskBoardComment
      */
@@ -92,7 +94,8 @@ public class TaskBoardCommentServiceImpl implements TaskBoardCommentService {
     public TaskBoardCommentDto deleteHard(Long taskBoardId, Long taskBoardCommentId) {
 
         // 업무 관리 게시글에 속한 댓글인지 확인
-        boolean isContaining = taskBoardCommentReader.checkCommentContaining(taskBoardId, taskBoardCommentId);
+        boolean isContaining = taskBoardCommentReader.checkCommentContaining(taskBoardId,
+            taskBoardCommentId);
         if (!isContaining) {
             throw new TaskBoardCommentMisMatchEntityException();
         }
@@ -107,5 +110,38 @@ public class TaskBoardCommentServiceImpl implements TaskBoardCommentService {
 
         // Entity -> Dto
         return TaskBoardCommentResponse.TaskBoardCommentDto.toDto(initComment);
+    }
+
+    /**
+     * 업무 관리 게시판 댓글 서비스 - 수정 기능
+     *
+     * @param taskBoardId 업무 관리 게시판 ID
+     * @param taskBoardCommentId 업무 관리 게시판 댓글 Id
+     * @param request TaskBoardCommentRequest.UpdateDto
+     * @return 수정된 TaskBoardComment
+     */
+    @Override
+    public TaskBoardCommentDto update(Long taskBoardId, Long taskBoardCommentId,
+        UpdateDto request) {
+
+        // 업무 관리 게시글에 속한 댓글인지 확인
+        boolean isContaining = taskBoardCommentReader.checkCommentContaining(taskBoardId,
+            taskBoardCommentId);
+        if (!isContaining) {
+            throw new TaskBoardCommentMisMatchEntityException();
+        }
+
+        // find TaskBoardComment Entity
+        TaskBoardComment initComment = taskBoardCommentReader.getByTaskBoardCommentId(
+            taskBoardCommentId).orElseThrow(TaskBoardCommentNotFoundEntityException::new);
+
+        // update
+        initComment.update(request.getContent());
+
+        // save
+        TaskBoardComment updatedComment = taskBoardCommentStore.store(initComment);
+
+        // Entity -> Dto
+        return TaskBoardCommentResponse.TaskBoardCommentDto.toDto(updatedComment);
     }
 }

--- a/module-service/src/main/java/com/checkping/service/project/TaskBoardService.java
+++ b/module-service/src/main/java/com/checkping/service/project/TaskBoardService.java
@@ -1,11 +1,12 @@
 package com.checkping.service.project;
 
 import com.checkping.dto.TaskBoardRequest;
-import com.checkping.dto.TaskBoardResponse;
-import com.checkping.dto.TaskBoardResponse.TaskBoardDto;
+import com.checkping.dto.TaskBoardResponse.TaskBoardItemDto;
+import com.checkping.dto.TaskBoardResponse.TaskBoardListDto;
 import java.util.List;
 
 public interface TaskBoardService {
-    TaskBoardResponse.TaskBoardDto register(TaskBoardRequest.RegisterDto request);
-    List<TaskBoardDto> getTaskBoardList(TaskBoardRequest.SearchCondition searchCondition);
+    TaskBoardItemDto register(TaskBoardRequest.RegisterDto request);
+    List<TaskBoardListDto> getTaskBoardList(TaskBoardRequest.SearchCondition searchCondition);
+    TaskBoardItemDto getTaskBoardById(Long taskBoardId);
 }

--- a/module-service/src/main/java/com/checkping/service/project/TaskBoardService.java
+++ b/module-service/src/main/java/com/checkping/service/project/TaskBoardService.java
@@ -9,4 +9,6 @@ public interface TaskBoardService {
     TaskBoardItemDto register(TaskBoardRequest.RegisterDto request);
     List<TaskBoardListDto> getTaskBoardList(TaskBoardRequest.SearchCondition searchCondition);
     TaskBoardItemDto getTaskBoardById(Long taskBoardId);
+    TaskBoardListDto deleteSoft (Long taskBoardId);
+    TaskBoardListDto deleteHard(Long taskBoardId);
 }

--- a/module-service/src/main/java/com/checkping/service/project/TaskBoardServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/TaskBoardServiceImpl.java
@@ -3,8 +3,9 @@ package com.checkping.service.project;
 import com.checkping.domain.board.TaskBoard;
 import com.checkping.dto.TaskBoardRequest;
 import com.checkping.dto.TaskBoardRequest.SearchCondition;
-import com.checkping.dto.TaskBoardResponse;
-import com.checkping.dto.TaskBoardResponse.TaskBoardDto;
+import com.checkping.dto.TaskBoardResponse.TaskBoardItemDto;
+import com.checkping.dto.TaskBoardResponse.TaskBoardListDto;
+import com.checkping.exception.project.TaskBoardNotFoundEntityException;
 import com.checkping.infra.repository.project.taskboard.TaskBoardReader;
 import com.checkping.infra.repository.project.taskboard.TaskBoardStore;
 import java.util.List;
@@ -25,7 +26,7 @@ public class TaskBoardServiceImpl implements TaskBoardService {
      * @return 생성한 TaskBoard 의 Dto
      */
     @Override
-    public TaskBoardResponse.TaskBoardDto register(TaskBoardRequest.RegisterDto request) {
+    public TaskBoardItemDto register(TaskBoardRequest.RegisterDto request) {
 
         // dto -> entity
         TaskBoard initTaskBoard = TaskBoardRequest.RegisterDto.toEntity(request);
@@ -35,24 +36,41 @@ public class TaskBoardServiceImpl implements TaskBoardService {
         TaskBoard taskBoard = taskBoardStore.store(initTaskBoard);
 
         // entity -> dto
-        return TaskBoardResponse.TaskBoardDto.toDto(taskBoard);
+        return TaskBoardItemDto.toDto(taskBoard);
     }
 
     /**
      * TaskBoard 조회 하기 (게시글 유형, 게시글 상태 별 필터링)
      *
      * @param searchCondition RequestParam 에서 받아오는 String 을 관리하는 타입
-     * @return 조회한 TaskBoardDto 의 리스트
+     * @return 조회한 TaskBoardListDto 의 리스트
      */
     @Override
-    public List<TaskBoardDto> getTaskBoardList(SearchCondition searchCondition) {
+    public List<TaskBoardListDto> getTaskBoardList(SearchCondition searchCondition) {
 
         // 조회
         List<TaskBoard> taskBoardList = taskBoardReader.getTaskBoard(
             searchCondition.getBoardCategory(),
             searchCondition.getBoardStatus());
 
-        // TaskBoard -> TaskBoardDto
-        return taskBoardList.stream().map(TaskBoardDto::toDto).toList();
+        // TaskBoard -> TaskBoardListDto
+        return taskBoardList.stream().map(TaskBoardListDto::toDto).toList();
+    }
+
+    /**
+     * 업무 관리 게시글 서비스 - 상세 조회
+     *
+     * @param taskBoardId 업무 관리 게시글 ID
+     * @return TaskBoardListDto
+     */
+    @Override
+    public TaskBoardItemDto getTaskBoardById(Long taskBoardId) {
+
+        // find TaskBoard Entity
+        TaskBoard taskBoard = taskBoardReader.getTaskBoardById(taskBoardId).orElseThrow(
+            TaskBoardNotFoundEntityException::new);
+
+        // Entity -> Dto
+        return TaskBoardItemDto.toDto(taskBoard);
     }
 }

--- a/module-service/src/main/java/com/checkping/service/project/TaskBoardServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/TaskBoardServiceImpl.java
@@ -1,13 +1,17 @@
 package com.checkping.service.project;
 
 import com.checkping.domain.board.TaskBoard;
+import com.checkping.domain.board.TaskBoardComment;
 import com.checkping.dto.TaskBoardRequest;
 import com.checkping.dto.TaskBoardRequest.SearchCondition;
+import com.checkping.dto.TaskBoardResponse;
 import com.checkping.dto.TaskBoardResponse.TaskBoardItemDto;
 import com.checkping.dto.TaskBoardResponse.TaskBoardListDto;
 import com.checkping.exception.project.TaskBoardNotFoundEntityException;
 import com.checkping.infra.repository.project.taskboard.TaskBoardReader;
 import com.checkping.infra.repository.project.taskboard.TaskBoardStore;
+import com.checkping.infra.repository.project.taskboardcomment.TaskBoardCommentReader;
+import com.checkping.infra.repository.project.taskboardcomment.TaskBoardCommentStore;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +22,8 @@ public class TaskBoardServiceImpl implements TaskBoardService {
 
     private final TaskBoardStore taskBoardStore;
     private final TaskBoardReader taskBoardReader;
+    private final TaskBoardCommentReader taskBoardCommentReader;
+    private final TaskBoardCommentStore taskBoardCommentStore;
 
     /**
      * 업무 관리 게시글 등록하기
@@ -72,5 +78,60 @@ public class TaskBoardServiceImpl implements TaskBoardService {
 
         // Entity -> Dto
         return TaskBoardItemDto.toDto(taskBoard);
+    }
+
+    /**
+     * 업무 관리 게시글 서비스 - SOFT DELETE
+     *
+     * @param taskBoardId 업무 관리 게시글 ID
+     * @return 상태 변경이 된 업무 관리 게시글 Dto
+     */
+    @Override
+    public TaskBoardListDto deleteSoft(Long taskBoardId) {
+
+        // find TaskBoard Entity
+        TaskBoard initTaskBoard = taskBoardReader.getTaskBoardById(taskBoardId).orElseThrow(
+            TaskBoardNotFoundEntityException::new);
+
+        // TaskBoardComment - SOFT DELETE
+        List<TaskBoardComment> commentList = initTaskBoard.getCommentList();
+        for (TaskBoardComment comment : commentList) {
+            comment.deactivate();
+            taskBoardCommentStore.store(comment);
+        }
+
+        // TaskBoard - SOFT DELETE
+        initTaskBoard.deactivate();
+
+        // save
+        TaskBoard deletedTaskBoard = taskBoardStore.store(initTaskBoard);
+
+        // Entity -> Dto
+        return TaskBoardResponse.TaskBoardListDto.toDto(deletedTaskBoard);
+    }
+
+    /**
+     * 업무 관리 게시글 서비스 - HARD DELETE
+     *
+     * @param taskBoardId 업무 관리 게시글 ID
+     * @return HARD DELETE 를 요청한 업무 관리 게시글 Dto
+     */
+    @Override
+    public TaskBoardListDto deleteHard(Long taskBoardId) {
+
+        // find TaskBoard Entity
+        TaskBoard initTaskBoard = taskBoardReader.getTaskBoardById(taskBoardId).orElseThrow(
+            TaskBoardNotFoundEntityException::new);
+
+        // TaskBoardComment - HARD DELETE
+        List<TaskBoardComment> commentList = initTaskBoard.getCommentList();
+        for (TaskBoardComment comment : commentList) {
+            taskBoardCommentStore.deleteHard(comment);
+        }
+
+        // TaskBoard - HARD DELETE
+        taskBoardStore.deleteHard(initTaskBoard);
+
+        return TaskBoardResponse.TaskBoardListDto.toDto(initTaskBoard);
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

**[업무 관리 게시글 삭제 기능]**

## #️⃣ 연관된 이슈

- #55 

## 📋 작업 내용

- 통일을 위한 TaskBoardCommentResponse Dto의 필드명 수정 (deletedStatus -> deletedYn)
- 개발의 편의성을 위해 TaskBoardResponseTaskBoardCommentResponse, dto의 생성자에 deletedYn 을 추가
- SOFT DELETE 와 HARD DELETE 를 나누어서 개발
  - HARD DELETE 의 엔드포인트는 추후 개발 예정
  - TaskBoardStore.deleteHard() 추가
- TaskBoardService 에 SOFT DELETE 와 HARD DELETE 메서드 추가
- **업무 관리 게시글이 삭제될 때, 업무 관리 게시글에 속한 댓글도 같이 수정 및 삭제되도록 구현**
- SOFT DELETE 기능 엔드포인트 추가
  - DELETE /posts/{postId}

