### PR TITLE
Feature/38 전체 프로젝트 목록 조회 및 검색

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/ProjectController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/ProjectController.java
@@ -9,6 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -39,5 +41,13 @@ public class ProjectController {
         ProjectResponse.ProjectDto projectDto = projectService.updateProject(projectId, request);
         log.info("FlowSync - updateProjects project_id : {}, name : {}, update_at : {}, updater_id : {}", projectDto.getId(), projectDto.getName(), projectDto.getUpdateAt(), projectDto.getUpdaterId());
         return BaseResponse.success(projectDto);
+    }
+
+    @GetMapping(value = {"/admins/projects", "/projects"})
+    public BaseResponse<List<ProjectResponse.ProjectDto>> listProjects(@RequestParam(required = false) String keyword, @RequestParam(required = false) String status) {
+
+        List<ProjectResponse.ProjectDto> projects = projectService.findAllProjects(keyword, status);
+        //log.info("FlowSync - getProjectlist : ");
+        return BaseResponse.success(projects);
     }
 }

--- a/module-domain/src/main/java/com/checkping/domain/member/Organization.java
+++ b/module-domain/src/main/java/com/checkping/domain/member/Organization.java
@@ -1,6 +1,7 @@
 package com.checkping.domain.member;
 
 import com.checkping.domain.BaseEntity;
+import com.checkping.domain.project.Project;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.UuidGenerator;
@@ -70,6 +71,10 @@ public class Organization extends BaseEntity {
 
     @Column(length = 100)
     private String remark;
+
+    @ManyToOne
+    @JoinColumn(name = "project_id")
+    private Project project;
 
     public enum Type {
         DEVELOPER, CUSTOMER

--- a/module-domain/src/main/java/com/checkping/domain/project/Project.java
+++ b/module-domain/src/main/java/com/checkping/domain/project/Project.java
@@ -1,9 +1,12 @@
 package com.checkping.domain.project;
 
 import com.checkping.domain.BaseEntity;
+import com.checkping.domain.member.Organization;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Getter
@@ -63,6 +66,13 @@ public class Project extends BaseEntity {
 
     @Column(name = "deleted_yn")
     private String deletedYn;
+
+    @OneToMany
+    @Builder.Default
+    @JoinTable(name = "organization_by_project",
+    joinColumns = @JoinColumn(name="project_id"),
+            inverseJoinColumns = @JoinColumn(name = "org_id", columnDefinition = "UUID"))
+    private List<Organization> organizations = new ArrayList<>();
 
     @Getter
     @RequiredArgsConstructor

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectRepository.java
@@ -2,6 +2,32 @@ package com.checkping.infra.repository.project;
 
 import com.checkping.domain.project.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+    @Query(value = "SELECT p.*, " +
+            "org_info.developer_type, " +
+            "org_info.developer_name, " +
+            "org_info.customer_type, " +
+            "org_info.customer_name " +
+            "FROM project p " +
+            "LEFT JOIN ( " +
+            "    SELECT obp.project_id, " +
+            "    MAX(CASE WHEN o.type = 'DEVELOPER' THEN o.type END) AS developer_type, " +
+            "    MAX(CASE WHEN o.type = 'DEVELOPER' THEN o.name END) AS developer_name, " +
+            "    MAX(CASE WHEN o.type = 'CUSTOMER' THEN o.type END) AS customer_type, " +
+            "    MAX(CASE WHEN o.type = 'CUSTOMER' THEN o.name END) AS customer_name " +
+            "    FROM organization_by_project obp " +
+            "    LEFT JOIN organization o ON obp.org_id = o.id " +
+            "    GROUP BY obp.project_id " +
+            ") AS org_info ON p.id = org_info.project_id " +
+            "WHERE (:keyword IS NULL OR p.name LIKE CONCAT('%', :keyword, '%')) " +
+            "AND (:status IS NULL OR p.status = :status)", nativeQuery = true)
+    List<Project> findProjectsWithOrganizationInfoByKeywordAndStatus(@Param("keyword") String keyword, @Param("status") String status);
+
+
 }

--- a/module-service/src/main/java/com/checkping/dto/ProjectResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/ProjectResponse.java
@@ -26,6 +26,11 @@ public class ProjectResponse {
         private Long updaterId;
         private String deletedYn;
 
+        private String developerType;
+        private String developerName;
+        private String customerType;
+        private String customerName;
+
         public static ProjectDto toDto(Project project) {
             ProjectDto projectDto = new ProjectDto();
             projectDto.setId(project.getId());
@@ -40,6 +45,13 @@ public class ProjectResponse {
             projectDto.setUpdaterId(project.getUpdaterId());
             projectDto.setDeletedYn(project.getDeletedYn());
             return projectDto;
+        }
+
+        public void setOrganizationInfo(String developerType, String developerName, String customerType, String customerName) {
+            this.developerType = developerType;
+            this.developerName = developerName;
+            this.customerType = customerType;
+            this.customerName = customerName;
         }
     }
 

--- a/module-service/src/main/java/com/checkping/service/project/ProjectService.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectService.java
@@ -3,10 +3,14 @@ package com.checkping.service.project;
 import com.checkping.dto.ProjectRequest;
 import com.checkping.dto.ProjectResponse;
 
+import java.util.List;
+
 public interface ProjectService {
     ProjectResponse.ProjectDto registerProject(ProjectRequest.ResisterDto request);
 
     ProjectResponse.ProjectDto deleteProject(Long projectId);
 
     ProjectResponse.ProjectDto updateProject(Long projectId, ProjectRequest.UpdateDto request);
+
+    List<ProjectResponse.ProjectDto> findAllProjects(String keyword, String status);
 }

--- a/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
@@ -13,6 +13,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import java.time.LocalDateTime;
 
 @Slf4j
@@ -60,6 +63,28 @@ public class ProjectServiceImpl implements ProjectService {
         project = projectRepository.save(ProjectRequest.UpdateDto.toEntity(request, project));
 
         return ProjectResponse.ProjectDto.toDto(project);
+    }
+
+
+    @Override
+    public List<ProjectResponse.ProjectDto> findAllProjects(String keyword, String status) {
+        List<Project> results = projectRepository.findProjectsWithOrganizationInfoByKeywordAndStatus(keyword, status);
+
+        return results.stream().map(result -> {
+            Project project = result;
+
+            ProjectResponse.ProjectDto projectDto = ProjectResponse.ProjectDto.toDto(project);
+
+            // 추가된 정보인 개발사 및 고객사 정보를 설정
+            projectDto.setOrganizationInfo(
+                    project.getOrganizations().get(0).getType().toString(), // developerType
+                    project.getOrganizations().get(0).getName(),            // developerName
+                    project.getOrganizations().get(1).getType().toString(), // customerType
+                    project.getOrganizations().get(1).getName()             // customerName
+            );
+
+            return projectDto;
+        }).collect(Collectors.toList());
     }
 
 }

--- a/module-service/src/test/java/com/checkping/service/ProjectServiceTests.java
+++ b/module-service/src/test/java/com/checkping/service/ProjectServiceTests.java
@@ -1,10 +1,13 @@
 package com.checkping.service;
 
+import com.checkping.domain.member.Organization;
 import com.checkping.domain.project.Project;
 import com.checkping.dto.ProjectRequest;
 import com.checkping.dto.ProjectResponse;
+import com.checkping.infra.repository.member.OrganizationRepository;
 import com.checkping.infra.repository.project.ProjectRepository;
 import com.checkping.service.project.ProjectServiceImpl;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,6 +15,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -23,6 +27,9 @@ public class ProjectServiceTests {
 
     @Autowired
     private ProjectRepository projectRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
 
     @Test
     public void resisterProject() {
@@ -96,6 +103,53 @@ public class ProjectServiceTests {
         for (int i = 0; i < list.size(); i++) {
             System.out.println("updateProject : " + list.get(i));
         }
+
+    }
+
+    @Test
+    @Transactional
+    public void findAllProject(){
+
+        // 테스트 업체 추가
+        Organization dev_organization = Organization.builder()
+                .name("DEV_kernel")
+                .type(Organization.Type.DEVELOPER)
+                .status(Organization.Status.ACTIVE)
+                .regAt(LocalDateTime.now())
+                .build();
+        organizationRepository.save(dev_organization);
+
+        Organization cust_organization = Organization.builder()
+                .name("CUST_kernel2")
+                .type(Organization.Type.CUSTOMER)
+                .status(Organization.Status.ACTIVE)
+                .regAt(LocalDateTime.now())
+                .build();
+        organizationRepository.save(cust_organization);
+        List<Organization> organizations = new ArrayList<>();
+
+        // 테스트 프로젝트 추가
+        Project project = Project.builder()
+                .name("이름")
+                .description("설명")
+                .detail("상세설명")
+                .status(Project.Status.IN_PROGRESS)
+                .regAt(LocalDateTime.now())
+                .closeAt(LocalDate.parse("2025-12-30").atStartOfDay())
+                .resisterId(49283L)
+                .organizations(organizations)
+                .build();
+
+        project.getOrganizations().add(dev_organization);
+        project.getOrganizations().add(cust_organization);
+
+        projectRepository.save(project);
+
+        List<Project> projects = projectRepository.findAll();
+        System.out.println("p : " + projects.get(0));
+
+        List<ProjectResponse.ProjectDto> list = projectService.findAllProjects("이름","IN_PROGRESS");
+        System.out.println(list);
 
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

전체 프로젝트 목록 조회 및 검색

## #️⃣ 연관된 이슈

#38 

## 📋 작업 내용
- ProjectController, ProjectService
    - 관리자 입장에서 전체 프로젝트를 조회
    - *추후 개발사/고객사의 프로젝트 조회 기능 추가 필요*
    - 프로젝트 정보와 해당 프로젝트의 개발사, 고객사의 정보 가져옴 (type, name)
- ProjectRepository
    - 프로젝트 정보 및 프로젝트의 업체 정보 가져오기 위한 Jpql 작성 
- Project, Organization
    - Project와 Organization 간의 관계 매핑
- ProjectResponse
    - 업체 유형별 type, name 필드를 추가하여, 프로젝트에 관련된 조직 정보 제공
- ProjectServiceTests
    - 프로젝트 조회 테스트
