### PR TITLE
Feature/127 JWT 페이로드 정보추가

### DIFF
--- a/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
@@ -79,11 +79,12 @@ public class JWTFilter extends OncePerRequestFilter {
         }
 
         // username, role 값을 획득
+        String name = jwtUtil.getName(accessToken);
         String email = jwtUtil.getEmail(accessToken);
         String role = jwtUtil.getRole(accessToken);
         String password = "PASSWORDFORTOKEN";
 
-        CustomUserDetails customUserDetails = new CustomUserDetails(email, role, password);
+        CustomUserDetails customUserDetails = new CustomUserDetails(name, email, role, password);
 
         Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authToken);

--- a/module-api/src/main/java/com/checkping/api/auth/filter/LoginFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/LoginFilter.java
@@ -1,5 +1,6 @@
 package com.checkping.api.auth.filter;
 
+import com.checkping.service.member.auth.CustomUserDetails;
 import com.checkping.service.member.util.JwtUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
@@ -70,10 +71,11 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
         GrantedAuthority auth = iterator.next();
         String role = auth.getAuthority();
+        String name = ((CustomUserDetails) authentication.getPrincipal()).getName();
 
         //토큰 생성
-        String access = jwtUtil.createJwt("access", email, role, 600000L);
-        String refresh = jwtUtil.createJwt("refresh", email, role, 86400000L);
+        String access = jwtUtil.createJwt("access", name, email, role, 15);
+        String refresh = jwtUtil.createJwt("refresh", name, email, role,1440);
 
         //응답 설정
         response.setHeader("access", access);

--- a/module-api/src/main/java/com/checkping/api/controller/ReissueController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/ReissueController.java
@@ -27,12 +27,13 @@ public class ReissueController {
             reissueService.checkTokenValidity(refresh);
 
             // Extract email and role
+            String name = reissueService.getNameFromToken(refresh);
             String email = reissueService.getEmailFromToken(refresh);
             String role = reissueService.getRoleFromToken(refresh);
 
             // Generate new tokens
-            String newAccess = reissueService.generateAccessToken(email, role);
-            String newRefresh = reissueService.generateRefreshToken(email, role);
+            String newAccess = reissueService.generateAccessToken(name, email, role);
+            String newRefresh = reissueService.generateRefreshToken(name, email, role);
 
             // Set response
             response.setHeader("access", newAccess);

--- a/module-service/src/main/java/com/checkping/dto/member/response/MemberResponseDto.java
+++ b/module-service/src/main/java/com/checkping/dto/member/response/MemberResponseDto.java
@@ -14,6 +14,7 @@ public class MemberResponseDto {
     private UUID organizationId;
     private String email;
     private String name;
+    private Member.Role role;
     private String phoneNum;
     private String jobRole;
     private String jobTitle;
@@ -28,6 +29,7 @@ public class MemberResponseDto {
                 .email(member.getEmail())
                 .name(member.getName())
                 .phoneNum(member.getPhoneNum())
+                .role(member.getRole())
                 .jobRole(member.getJobRole())
                 .jobTitle(member.getJobTitle())
                 .status(member.getStatus())

--- a/module-service/src/main/java/com/checkping/service/member/auth/CustomUserDetails.java
+++ b/module-service/src/main/java/com/checkping/service/member/auth/CustomUserDetails.java
@@ -1,5 +1,6 @@
 package com.checkping.service.member.auth;
 
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -8,14 +9,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+@Getter
 public class CustomUserDetails implements UserDetails {
 
-
+    private String name;
     private String email;
     private String role;
     private String password;
 
-    public CustomUserDetails(String email, String role, String password) {
+    public CustomUserDetails(String name, String email, String role, String password) {
+        this.name = name;
         this.email = email;
         this.role = role;
         this.password = password;
@@ -49,6 +52,7 @@ public class CustomUserDetails implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         // Member 엔티티의 role 필드를 GrantedAuthority로 변환
         List<GrantedAuthority> authorities = new ArrayList<>();
+        // ROLE_USER, ROLE_ADMIN 형식
         authorities.add(new SimpleGrantedAuthority("ROLE_" + role)); // ROLE_ADMIN, ROLE_MEMBER 형식
         return authorities;
     }

--- a/module-service/src/main/java/com/checkping/service/member/auth/CustomUserDetailsService.java
+++ b/module-service/src/main/java/com/checkping/service/member/auth/CustomUserDetailsService.java
@@ -28,7 +28,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         if (member != null) {
 
             //UserDetails에 담아서 return하면 AutneticationManager가 검증 함
-            return new CustomUserDetails(member.getEmail(), member.getRole().toString(), member.getPassword());
+            return new CustomUserDetails(member.getName(), member.getEmail(), member.getRole().toString(), member.getPassword());
         }
 
         return null;

--- a/module-service/src/main/java/com/checkping/service/member/auth/ReissueService.java
+++ b/module-service/src/main/java/com/checkping/service/member/auth/ReissueService.java
@@ -40,6 +40,14 @@ public class ReissueService {
         }
     }
 
+    public String getCategoryFromToken(String token) {
+        return jwtUtil.getCategory(token);
+    }
+
+    public String getNameFromToken(String token) {
+        return jwtUtil.getName(token);
+    }
+
     public String getEmailFromToken(String token) {
         return jwtUtil.getEmail(token); // JwtUtil에서 호출
     }
@@ -48,11 +56,11 @@ public class ReissueService {
         return jwtUtil.getRole(token); // JwtUtil에서 호출
     }
 
-    public String generateAccessToken(String email, String role) {
-        return jwtUtil.createJwt("access", email, role, 600000L);
+    public String generateAccessToken(String name, String email, String role) {
+        return jwtUtil.createJwt("access", name, email, role, 15);
     }
 
-    public String generateRefreshToken(String email, String role) {
-        return jwtUtil.createJwt("refresh", email, role, 86400000L);
+    public String generateRefreshToken(String name, String email, String role) {
+        return jwtUtil.createJwt("refresh", name, email, role, 1440);
     }
 }

--- a/module-service/src/main/java/com/checkping/service/member/util/JwtUtil.java
+++ b/module-service/src/main/java/com/checkping/service/member/util/JwtUtil.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.time.ZonedDateTime;
 import java.util.Date;
 
 @Component
@@ -35,19 +36,27 @@ public class JwtUtil {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().get("role", String.class);
     }
 
+    public String getName(String token) {
+
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().get("name", String.class);
+    }
+
     public Boolean isExpired(String token) {
 
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getExpiration().before(new Date());
     }
 
-    public String createJwt(String category, String email, String role, Long expiredMs) {
+    public String createJwt(String category, String name, String email, String role, int expiredMin) {
 
         return Jwts.builder()
                 .claim("category", category)
+                .claim("name", name)
                 .claim("email", email)
                 .claim("role", role)
-                .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + expiredMs))
+                //토큰 발급시간 설정- 현재시간
+                .setIssuedAt(Date.from(ZonedDateTime.now().toInstant()))
+                //토큰 만료시간 설정- 현재시간 + expiredMin
+                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(expiredMin).toInstant()))
                 .signWith(key)
                 .compact();
     }


### PR DESCRIPTION
# 🚀 Pull Request

JWT 페이로드 정보 추가

## #️⃣ 연관된 이슈

#127 

## 📋 작업 내용

- CustomUserDetails : String name, 멤버 이름 필드 추가
- CustomUserDetailsService : 유저 디테일에 이름 값 포함 리턴
- JwtUtil : - 토큰에서 이름 정보 추출하는 getName 메서드 추가 - 만료 시간 밀리초에서 분으로 형식 변경

- JwtFilter : - access token에서 추출하는 정보에 멤버 이름 name 추가 - CustomUserDetails 객체를 생성하여 사용자 정보를 SecurityContext에 설정.

- MemberResponseDto : role 필드 추가
- ReissueController : 토큰 생성에 사용자 이름 추가
- ReissueService : - getCategoryFromToken() 메서드 추가 - getNameFromToken() 메서드 추가
