### PR TITLE
Chore/134 chore 로그인 기능 수정

### DIFF
--- a/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
@@ -39,6 +39,12 @@ public class JWTFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
+        // 권한이 필요 없는 요청은 필터를 통과시키기 위해 예외 처리
+        String requestURI = request.getRequestURI();
+        if (requestURI.equals("/login") || requestURI.equals("/reissue")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
         // 헤더에서 access키에 담긴 토큰을 꺼냄
         String accessToken = request.getHeader("access");
 

--- a/module-api/src/main/java/com/checkping/api/auth/filter/LoginFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/LoginFilter.java
@@ -76,7 +76,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String refresh = jwtUtil.createJwt("refresh", email, role, 86400000L);
 
         //응답 설정
-        response.setHeader("access", access);
+        response.setHeader("Authorization", "Bearer " + access);
         response.addCookie(createCookie("refresh", refresh));
         response.setStatus(HttpStatus.OK.value());
 

--- a/module-api/src/main/java/com/checkping/api/controller/ReissueController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/ReissueController.java
@@ -35,7 +35,7 @@ public class ReissueController {
             String newRefresh = reissueService.generateRefreshToken(email, role);
 
             // Set response
-            response.setHeader("access", newAccess);
+            response.setHeader("Authorization", "Bearer " + newAccess);
             response.addCookie(createCookie("refresh", newRefresh));
 
             return new ResponseEntity<>(HttpStatus.OK);


### PR DESCRIPTION
# 🚀 Pull Request

- 토큰 응답 시 매개변수 수정 
- 권한이 필요없는 경우에도 만료된 토큰이 들어오면 접근 차단하는 문제 해결 

## #️⃣ 연관된 이슈

#134 

## 📋 작업 내용

- 액세스 토큰 응답을 헤더에 넣을 때 토큰 String 앞에 Bearer를 붙임
- Http 응답의 헤더명 변경 
- /reissue 및 /login URL로 접근은 권한이 필요없기 때문에 만료된 토큰이 들어오더라도 상관없이 접근할 수 있도록 필터를 벗어나는 코드 추가 
