### PR TITLE
Chore/156 로그인 기능 수정

### DIFF
--- a/module-api/src/main/java/com/checkping/api/auth/filter/LoginFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/LoginFilter.java
@@ -1,5 +1,6 @@
 package com.checkping.api.auth.filter;
 
+import com.checkping.common.enums.ErrorCode;
 import com.checkping.common.response.BaseResponse;
 import com.checkping.service.member.auth.CustomUserDetails;
 import com.checkping.service.member.util.JwtUtil;
@@ -74,7 +75,15 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
         GrantedAuthority auth = iterator.next();
         String role = auth.getAuthority();
-        String name = ((CustomUserDetails) authentication.getPrincipal()).getName();
+        Object principal = authentication.getPrincipal();
+        String name;
+
+        if (principal instanceof CustomUserDetails) {
+            name = ((CustomUserDetails) principal).getName();
+        } else {
+            // CustomUserDetails가 아닌 경우 예외 발생
+            throw new IllegalStateException(ErrorCode.UNKNOWN_USER.getMessage());
+        }
 
         //토큰 생성
         String access = jwtUtil.createJwt("access", name, email, role, 15);

--- a/module-api/src/main/java/com/checkping/api/auth/filter/LoginFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/LoginFilter.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -26,6 +27,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public LoginFilter(AuthenticationManager authenticationManager, JwtUtil jwtUtil) {
 
@@ -45,7 +47,6 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
             }
 
             // JSON 파싱 (Jackson ObjectMapper 사용)
-            ObjectMapper objectMapper = new ObjectMapper();
             Map<String, String> credentials = objectMapper.readValue(jsonBuilder.toString(), Map.class);
 
             String email = credentials.get("email");
@@ -58,7 +59,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
             return authenticationManager.authenticate(authToken);
 
         } catch (IOException e) {
-            throw new RuntimeException("Failed to read the request body", e);
+            throw new BadCredentialsException("Failed to read the request body", e);
         }
     }
 

--- a/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
+++ b/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
         400 Bad Request
     */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 형식 또는 누락된 데이터가 있습니다."),
+    UNKNOWN_USER(HttpStatus.BAD_REQUEST, "알 수 없는 사용자입니다."),
 
     /*
         401 Unauthorized


### PR DESCRIPTION
# 🚀 Pull Request

LoginFilter 수정

## #️⃣ 연관된 이슈

#156 

## 📋 작업 내용

- attemptAuthentication 내부에서 매번 요청이 올 때마다 새로 생성하던 ObjectMapper 객체를 외부에 priavte final로 빼내어 선언함

- attemptAuthentication 에서 에러를 잡았을 때 RuntimeException으로 래핑하지 않고, 인증 관련 예외를 래핑하는 AuthenticationException을 사용함

- authentication.getPrincipal()을 별도의 과정 없이 업캐스팅하는 부분을 타입 확인 후 업캐스팅 하도록 수정 
- 타입이 다를 경우 발생하는 예외의 처리
- 예외처리시 반환할 ErrorCode 추가
