### PR TITLE
Feature/124 feature 프로젝트 생성 시 담당업체/담당자 정보 등록

### DIFF
--- a/module-domain/src/main/java/com/checkping/domain/member/Organization.java
+++ b/module-domain/src/main/java/com/checkping/domain/member/Organization.java
@@ -1,7 +1,6 @@
 package com.checkping.domain.member;
 
 import com.checkping.domain.BaseEntity;
-import com.checkping.domain.project.Project;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.UuidGenerator;
@@ -71,10 +70,6 @@ public class Organization extends BaseEntity {
 
     @Column(length = 100)
     private String remark;
-
-    @ManyToOne
-    @JoinColumn(name = "project_id")
-    private Project project;
 
     public enum Type {
         DEVELOPER, CUSTOMER

--- a/module-domain/src/main/java/com/checkping/domain/project/Project.java
+++ b/module-domain/src/main/java/com/checkping/domain/project/Project.java
@@ -1,6 +1,7 @@
 package com.checkping.domain.project;
 
 import com.checkping.domain.BaseEntity;
+import com.checkping.domain.member.Member;
 import com.checkping.domain.member.Organization;
 import jakarta.persistence.*;
 import lombok.*;
@@ -71,14 +72,23 @@ public class Project extends BaseEntity {
     @Column(name = "deleted_yn")
     private String deletedYn;
 
-//    todo : 개발 서버 DB 설정을 위해 임의로 주석 처리했습니다. @KJU3
-//    @OneToMany
-//    @Builder.Default
-//    @JoinTable(name = "organization_by_project",
-//    joinColumns = @JoinColumn(name = "project_id"),
-//            inverseJoinColumns = @JoinColumn(name = "org_id", columnDefinition = "UUID"))
-    @OneToMany(mappedBy = "project")
+    @ManyToMany(fetch = FetchType.LAZY)
+    @Builder.Default
+    @JoinTable(name = "organization_by_project",
+            joinColumns = @JoinColumn(name="project_id"),
+            inverseJoinColumns = @JoinColumn(name = "org_id", referencedColumnName = "id", columnDefinition = "BINARY(16)"),
+            uniqueConstraints =
+            @UniqueConstraint(columnNames = {"project_id","org_id"}))
     private List<Organization> organizations = new ArrayList<>();
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @Builder.Default
+    @JoinTable(name = "member_by_project",
+            joinColumns = @JoinColumn(name="project_id"),
+            inverseJoinColumns = @JoinColumn(name = "member_id", referencedColumnName = "id", columnDefinition = "BINARY(16)"),
+            uniqueConstraints =
+            @UniqueConstraint(columnNames = {"project_id","member_id"}))
+    private List<Member> members = new ArrayList<>();
 
     @Getter
     @RequiredArgsConstructor

--- a/module-service/src/main/java/com/checkping/dto/ProjectRequest.java
+++ b/module-service/src/main/java/com/checkping/dto/ProjectRequest.java
@@ -1,12 +1,14 @@
 package com.checkping.dto;
 
+import com.checkping.domain.member.Member;
+import com.checkping.domain.member.Organization;
 import com.checkping.domain.project.Project;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
-import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -44,7 +46,12 @@ public class ProjectRequest {
         private LocalDateTime closeAt;
         private Long resisterId;
 
-        public static Project toEntity(ResisterDto resisterDto) {
+        private String developerOrgId;
+        private String customerOrgId;
+
+        private List<String> members;
+
+        public static Project toEntity(ResisterDto resisterDto, List<Organization> organizations, List<Member> members) {
             return Project.builder()
                 .name(resisterDto.getName())
                 .description(resisterDto.getDescription())
@@ -53,6 +60,8 @@ public class ProjectRequest {
                 .startAt(resisterDto.getStartAt())
                 .closeAt(resisterDto.getCloseAt())
                 .resisterId(resisterDto.getResisterId())
+                .organizations(organizations)
+                .members(members)
                 .deletedYn("N")
                 .build();
         }

--- a/module-service/src/main/java/com/checkping/dto/ProjectResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/ProjectResponse.java
@@ -41,9 +41,7 @@ public class ProjectResponse {
         private Long updaterId;
         private String deletedYn;
 
-        private String developerType;
         private String developerName;
-        private String customerType;
         private String customerName;
 
         public static ProjectDto toDto(Project project) {
@@ -60,13 +58,13 @@ public class ProjectResponse {
             projectDto.setResisterId(project.getResisterId());
             projectDto.setUpdaterId(project.getUpdaterId());
             projectDto.setDeletedYn(project.getDeletedYn());
+            projectDto.setDeveloperName(project.getOrganizations().get(0).getName());
+            projectDto.setCustomerName(project.getOrganizations().get(1).getName());
             return projectDto;
         }
 
-        public void setOrganizationInfo(String developerType, String developerName, String customerType, String customerName) {
-            this.developerType = developerType;
+        public void setOrganizationInfo(String developerName, String customerName) {
             this.developerName = developerName;
-            this.customerType = customerType;
             this.customerName = customerName;
         }
     }


### PR DESCRIPTION
# 🚀 Pull Request

프로젝트 생성 시 담당업체/담당자 정보 등록

## #️⃣ 연관된 이슈

#124 

## 📋 작업 내용

- ProjectServiceImpl
    - 프로젝트 생성 시 업체 정보(개발사/고객사), 담당자 정보 함께 추가됨
    
- Project
    - Project-organization, project-member 간 관계 테이블인 project_by_organization, project_by_member 테이블 생성 위한 코드 작성
- Organization
    - 관계의 주체를 Project로 설정하기 위해 코드 삭제
    - Organization에서는 projects를 조회하지 않음
   
- ProjectRequest
    - 프로젝트 생성 시 개발사ID, 고객사ID, 멤버ID 리스트 입력
- ProjectResponse
    - 프로젝트 생성 시 개발사명, 고객사명 리턴