### PR TITLE
Chore/156 로그인 기능 수정

### DIFF
--- a/module-api/src/main/java/com/checkping/api/auth/filter/CustomLogoutFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/CustomLogoutFilter.java
@@ -83,7 +83,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
 
         //로그아웃 진행
 
-        //Refresh 토큰 Cookie 값 0
+        // Refresh 토큰 Cookie 값 0
         Cookie cookie = new Cookie("refresh", null);
         cookie.setMaxAge(0);
         cookie.setPath("/");

--- a/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
@@ -1,6 +1,7 @@
 package com.checkping.api.auth.filter;
 
 
+import com.checkping.api.auth.util.ResponseUtil;
 import com.checkping.common.enums.ErrorCode;
 import com.checkping.common.response.BaseResponse;
 import com.checkping.service.member.util.JwtUtil;
@@ -81,12 +82,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
             // 실패 응답 생성 (BaseResponse 활용)
             BaseResponse<Void> errorResponse = BaseResponse.fail(ErrorCode.UNAUTHORIZED);
-
-            // 응답 설정
-            response.setContentType("application/json");
-            response.setCharacterEncoding("UTF-8");
-            response.setStatus(HttpStatus.UNAUTHORIZED.value());
-            response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
+            ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
             return;
         }
 
@@ -98,12 +94,8 @@ public class JWTFilter extends OncePerRequestFilter {
             jwtUtil.isExpired(accessToken);
         } catch (ExpiredJwtException e) {
 
-            //response body
-            PrintWriter writer = response.getWriter();
-            writer.print("access token expired");
-
-            //response status code
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            String errorMessage = "access token expired";
+            ResponseUtil.sendErrorResponse(response, HttpStatus.valueOf(HttpServletResponse.SC_UNAUTHORIZED), errorMessage);
             return;
         }
 
@@ -111,13 +103,8 @@ public class JWTFilter extends OncePerRequestFilter {
         String category = jwtUtil.getCategory(accessToken);
 
         if (!category.equals("access")) {
-
-            //response body
-            PrintWriter writer = response.getWriter();
-            writer.print("invalid access token");
-
-            //response status code
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 애러 응답 때, 리프레시 토큰으로 재발급 받을 수 있도록 프론트와 결정
+            String errorMessage = "invalid access token";
+            ResponseUtil.sendErrorResponse(response, HttpStatus.valueOf(HttpServletResponse.SC_UNAUTHORIZED), errorMessage);
             return;
         }
 

--- a/module-api/src/main/java/com/checkping/api/auth/filter/LoginFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/LoginFilter.java
@@ -26,6 +26,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public LoginFilter(AuthenticationManager authenticationManager, JwtUtil jwtUtil) {
 
@@ -45,7 +46,6 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
             }
 
             // JSON 파싱 (Jackson ObjectMapper 사용)
-            ObjectMapper objectMapper = new ObjectMapper();
             Map<String, String> credentials = objectMapper.readValue(jsonBuilder.toString(), Map.class);
 
             String email = credentials.get("email");

--- a/module-api/src/main/java/com/checkping/api/auth/filter/LoginFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/LoginFilter.java
@@ -1,5 +1,6 @@
 package com.checkping.api.auth.filter;
 
+import com.checkping.api.auth.util.ResponseUtil;
 import com.checkping.common.response.BaseResponse;
 import com.checkping.service.member.auth.CustomUserDetails;
 import com.checkping.service.member.util.JwtUtil;
@@ -81,14 +82,10 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         BaseResponse<Map<String, String>> successResponse = BaseResponse.success("로그인에 성공하였습니다.");
 
-        //응답 설정
-        response.setStatus(HttpStatus.OK.value());
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-        response.setHeader("Authorization", "Bearer " + access);
-        response.addCookie(createCookie("refresh", refresh));
-        response.getWriter().write(new ObjectMapper().writeValueAsString(successResponse));
+        // JWT와 쿠키 포함된 성공 응답
+        ResponseUtil.sendSuccessWithJwtAndCookie(response, HttpStatus.OK, successResponse, access, refresh);
     }
+
 
     //로그인 실패시 실행하는 메소드
     @Override
@@ -101,24 +98,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
                 "error", "Fail",
                 "message", "로그인에 실패했습니다. 아이디와 비밀번호를 다시 확인해주세요."
         );
-
-        // 응답 설정
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
-        response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
-
-    }
-
-    private Cookie createCookie(String key, String value) {
-
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(24*60*60);
-        //cookie.setSecure(true);
-        //cookie.setPath("/");
-        cookie.setHttpOnly(true);
-
-        return cookie;
+        ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
     }
 }
 

--- a/module-api/src/main/java/com/checkping/api/auth/util/ResponseUtil.java
+++ b/module-api/src/main/java/com/checkping/api/auth/util/ResponseUtil.java
@@ -1,0 +1,49 @@
+package com.checkping.api.auth.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+
+import java.io.IOException;
+
+public class ResponseUtil {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24*60*60);
+        //cookie.setSecure(true);
+        //cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+    // 실패 응답 생성
+    public static void sendErrorResponse(HttpServletResponse response, HttpStatus status, Object errorResponse) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(status.value());
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+
+    // 성공 응답 생성
+    public static void sendSuccessResponse(HttpServletResponse response, HttpStatus status, Object successResponse) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(status.value());
+        response.getWriter().write(objectMapper.writeValueAsString(successResponse));
+    }
+
+    // JWT와 쿠키 설정 포함 응답
+    public static void sendSuccessWithJwtAndCookie(HttpServletResponse response, HttpStatus status, Object successResponse, String accessToken, String refreshToken) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(status.value());
+        response.setHeader("Authorization", "Bearer " + accessToken);
+        response.addCookie(createCookie("refresh", refreshToken));
+        response.getWriter().write(objectMapper.writeValueAsString(successResponse));
+    }
+}

--- a/module-api/src/main/java/com/checkping/api/auth/util/ResponseUtil.java
+++ b/module-api/src/main/java/com/checkping/api/auth/util/ResponseUtil.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 public class ResponseUtil {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    private static Cookie createCookie(String key, String value) {
+    public static Cookie createCookie(String key, String value) {
 
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge(24*60*60);

--- a/module-api/src/main/java/com/checkping/api/controller/ReissueController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/ReissueController.java
@@ -1,5 +1,6 @@
 package com.checkping.api.controller;
 
+import com.checkping.api.auth.util.ResponseUtil;
 import com.checkping.common.response.BaseResponse;
 import com.checkping.service.member.auth.ReissueService;
 import jakarta.servlet.http.Cookie;
@@ -37,15 +38,15 @@ public class ReissueController {
 
         // Set response
         response.setHeader("Authorization", "Bearer " + newAccess);
-        response.addCookie(createCookie("refresh", newRefresh));
+        response.addCookie(ResponseUtil.createCookie("refresh", newRefresh));
 
         return BaseResponse.success("Reissue success");
     }
 
-    private Cookie createCookie(String key, String value) {
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(24 * 60 * 60);
-        cookie.setHttpOnly(true);
-        return cookie;
-    }
+//    private Cookie createCookie(String key, String value) {
+//        Cookie cookie = new Cookie(key, value);
+//        cookie.setMaxAge(24 * 60 * 60);
+//        cookie.setHttpOnly(true);
+//        return cookie;
+//    }
 }

--- a/module-api/src/main/java/com/checkping/api/controller/ReissueController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/ReissueController.java
@@ -42,11 +42,4 @@ public class ReissueController {
 
         return BaseResponse.success("Reissue success");
     }
-
-//    private Cookie createCookie(String key, String value) {
-//        Cookie cookie = new Cookie(key, value);
-//        cookie.setMaxAge(24 * 60 * 60);
-//        cookie.setHttpOnly(true);
-//        return cookie;
-//    }
 }

--- a/module-service/src/main/java/com/checkping/service/member/MemberService.java
+++ b/module-service/src/main/java/com/checkping/service/member/MemberService.java
@@ -37,7 +37,7 @@ public class MemberService {
         return MemberResponseDto.fromEntity(member);
     }
 
-    //모든 회원 목록 조회
+    // 모든 회원 목록 조회
     public MemberListResponseDto getAllMemberListAsDto() {
         List<Member> members = memberRepository.findAll();
         return MemberListResponseDto.fromEntityList(members);


### PR DESCRIPTION
# 🚀 Pull Request

로그인 기능 수정

## #️⃣ 연관된 이슈

#156

## 📋 작업 내용

- attempAuthentication 메서드 내부에서 요청을 받을 때마다 생성하던 ObjectMapper 객체를 외부에서 final로 선언해놓음

- LoginFilter와 JWTFilter에 있는 중복되는 성공 및 실패 응답들과 쿠키생성로직을 별도로 분리해 ResponseUtil에서 관리

- ResponseUtil과 ReissueController에 createCookie 메서드가 똑같이 들어가 있어 ReissueController에 들어있는 메서드를 제거

- ReissueController에 createCookie 메서드가 사라짐에 따라 createCookie 메서드를 이후에도 해당 클래스에서 사용가능하게 하기 위해 ResponseUtil 클래스와 내부의 createCookie 메서드를 public으로 전환
