### PR TITLE
feat: MemberListResponseDto에 메타데이터 추가

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/member/MemberApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/member/MemberApi.java
@@ -25,7 +25,7 @@ public interface MemberApi {
 
     @Operation(summary = "전체 회원 조회", description = "페이징 지원을 포함한 전체 회원 목록을 조회하는 기능입니다.")
     BaseResponse<MemberListResponseDto> getAllMembers(
-            @Parameter(description = "페이지 번호 (1부터 시작)", example = "0", required = true)
+            @Parameter(description = "페이지 번호 (1부터 시작)", example = "1", required = true)
             int page,
             @Parameter(description = "페이지 크기", example = "10", required = true)
             int size);

--- a/module-service/src/main/java/com/checkping/dto/member/response/MemberListResponseDto.java
+++ b/module-service/src/main/java/com/checkping/dto/member/response/MemberListResponseDto.java
@@ -5,42 +5,33 @@ import lombok.Getter;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 @Getter
 public class MemberListResponseDto {
 
     private final List<MemberResponseDto> members;
-    private long totalElements;
-    private int totalPages;
+    private final Map<String, Object> meta;
 
-    public MemberListResponseDto(List<MemberResponseDto> members) {
+    public MemberListResponseDto(List<MemberResponseDto> members, Map<String, Object> meta) {
         this.members = members;
+        this.meta = meta;
     }
 
     public static MemberListResponseDto fromEntityPage(Page<Member> page) {
         List<MemberResponseDto> memberDtos = page.getContent().stream()
                 .map(MemberResponseDto::fromEntity)
                 .toList();
-        return new MemberListResponseDto(memberDtos, page.getTotalElements(), page.getTotalPages());
-    }
 
-    // 생성자와 Getter 추가
-    public MemberListResponseDto(List<MemberResponseDto> members, long totalElements, int totalPages) {
-        this.members = members;
-        this.totalElements = totalElements;
-        this.totalPages = totalPages;
-    }
+        Map<String, Object> meta = Map.of(
+                "totalElements", page.getTotalElements(),   // 전체 원소 개수
+                "isFirstPage", page.isFirst(),              // 첫 번째 페이지 여부
+                "isLastPage", page.isLast(),                // 마지막 페이지 여부
+                "totalPages", page.getTotalPages(),         // 전체 페이지 개수
+                "pageSize", page.getSize(),                 // 한 페이지당 원소 개수
+                "currentPage", page.getNumber() + 1             // 현재 페이지 번호
+        );
 
-    public List<MemberResponseDto> getMembers() {
-        return members;
-    }
-
-    public long getTotalElements() {
-        return totalElements;
-    }
-
-    public int getTotalPages() {
-        return totalPages;
+        return new MemberListResponseDto(memberDtos, meta);
     }
 }

--- a/module-service/src/main/java/com/checkping/service/member/MemberService.java
+++ b/module-service/src/main/java/com/checkping/service/member/MemberService.java
@@ -44,11 +44,6 @@ public class MemberService {
         return MemberResponseDto.fromEntity(member);
     }
 
-    //모든 회원 목록 조회
-//    public MemberListResponseDto getAllMemberListAsDto() {
-//        List<Member> members = memberRepository.findAll();
-//        return MemberListResponseDto.fromEntityList(members);
-//    }
     // 페이징된 전체 회원 목록 조회
     public MemberListResponseDto getAllMembersWithPaging(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);


### PR DESCRIPTION
# 🚀 Pull Request

멤버 조회 기능에 메타데이터 조회 추가

## #️⃣ 연관된 이슈

#197

## 📋 작업 내용

- MemberListResponseDto에 'meta' 필드를 추가하여 페이징 관련 메타데이터 반환 기능 구현
  - totalElements, isFirstPage, isLastPage, totalPages, pageSize, currentPage 정보 포함
- fromEntityPage 메서드 수정:
  - Page 객체에서 메타데이터를 추출하고 Map으로 변환해 저장
- 기존 데이터 리스트와 메타데이터를 동시에 반환하도록 구조 변경
