### PR TITLE
Feature/197 멤버 페이징 기능 구현

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/member/MemberApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/member/MemberApi.java
@@ -25,7 +25,7 @@ public interface MemberApi {
 
     @Operation(summary = "전체 회원 조회", description = "페이징 지원을 포함한 전체 회원 목록을 조회하는 기능입니다.")
     BaseResponse<MemberListResponseDto> getAllMembers(
-            @Parameter(description = "페이지 번호 (1부터 시작)", example = "0", required = true)
+            @Parameter(description = "페이지 번호 (1부터 시작)", example = "1", required = true)
             int page,
             @Parameter(description = "페이지 크기", example = "10", required = true)
             int size);

--- a/module-api/src/main/java/com/checkping/api/controller/member/MemberController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/member/MemberController.java
@@ -33,9 +33,9 @@ public class MemberController implements MemberApi {
     @Override
     @GetMapping
     public BaseResponse<MemberListResponseDto> getAllMembers(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size) {
-        MemberListResponseDto response = memberService.getAllMembersWithPaging(page-1, size);
+            @RequestParam(defaultValue = "1") int currentPage,
+            @RequestParam(defaultValue = "10") int pageSize) {
+        MemberListResponseDto response = memberService.getAllMembersWithPaging(currentPage-1, pageSize);
         return BaseResponse.success(response);
     }
 

--- a/module-common/src/main/java/com/checkping/common/dto/PageMetaResponse.java
+++ b/module-common/src/main/java/com/checkping/common/dto/PageMetaResponse.java
@@ -1,7 +1,6 @@
 package com.checkping.common.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.data.domain.Page;
 import lombok.Getter;
 
 import java.util.Map;
@@ -24,7 +23,7 @@ public class PageMetaResponse {
         this.currentPage = currentPage;
     }
 
-    public static PageMetaResponse fromPage(org.springframework.data.domain.Page<?> page) {
+    public static PageMetaResponse fromPage(Page<?> page) {
         return new PageMetaResponse(
                 page.getTotalElements(),
                 page.isFirst(),

--- a/module-common/src/main/java/com/checkping/common/dto/PageMetaResponse.java
+++ b/module-common/src/main/java/com/checkping/common/dto/PageMetaResponse.java
@@ -1,4 +1,4 @@
-package com.checkping.common.response;
+package com.checkping.common.dto;
 
 import lombok.Getter;
 

--- a/module-common/src/main/java/com/checkping/common/dto/PageMetaResponse.java
+++ b/module-common/src/main/java/com/checkping/common/dto/PageMetaResponse.java
@@ -1,5 +1,7 @@
 package com.checkping.common.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 import java.util.Map;

--- a/module-common/src/main/java/com/checkping/common/response/PageMetaResponse.java
+++ b/module-common/src/main/java/com/checkping/common/response/PageMetaResponse.java
@@ -1,0 +1,46 @@
+package com.checkping.common.response;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class PageMetaResponse {
+    private final long totalElements;
+    private final boolean isFirstPage;
+    private final boolean isLastPage;
+    private final int totalPages;
+    private final int pageSize;
+    private final int currentPage;
+
+    public PageMetaResponse(long totalElements, boolean isFirstPage, boolean isLastPage, int totalPages, int pageSize, int currentPage) {
+        this.totalElements = totalElements;
+        this.isFirstPage = isFirstPage;
+        this.isLastPage = isLastPage;
+        this.totalPages = totalPages;
+        this.pageSize = pageSize;
+        this.currentPage = currentPage;
+    }
+
+    public static PageMetaResponse fromPage(org.springframework.data.domain.Page<?> page) {
+        return new PageMetaResponse(
+                page.getTotalElements(),
+                page.isFirst(),
+                page.isLast(),
+                page.getTotalPages(),
+                page.getSize(),
+                page.getNumber() + 1
+        );
+    }
+
+    public Map<String, Object> toMap() {
+        return Map.of(
+                "totalElements", totalElements,
+                "isFirstPage", isFirstPage,
+                "isLastPage", isLastPage,
+                "totalPages", totalPages,
+                "pageSize", pageSize,
+                "currentPage", currentPage
+        );
+    }
+}

--- a/module-service/src/main/java/com/checkping/dto/member/response/MemberListResponseDto.java
+++ b/module-service/src/main/java/com/checkping/dto/member/response/MemberListResponseDto.java
@@ -1,46 +1,30 @@
 package com.checkping.dto.member.response;
 
+import com.checkping.common.response.PageMetaResponse;
 import com.checkping.domain.member.Member;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 public class MemberListResponseDto {
 
     private final List<MemberResponseDto> members;
-    private long totalElements;
-    private int totalPages;
+    private final PageMetaResponse meta;
 
-    public MemberListResponseDto(List<MemberResponseDto> members) {
+    public MemberListResponseDto(List<MemberResponseDto> members, PageMetaResponse meta) {
         this.members = members;
+        this.meta = meta;
     }
 
     public static MemberListResponseDto fromEntityPage(Page<Member> page) {
         List<MemberResponseDto> memberDtos = page.getContent().stream()
                 .map(MemberResponseDto::fromEntity)
                 .toList();
-        return new MemberListResponseDto(memberDtos, page.getTotalElements(), page.getTotalPages());
-    }
 
-    // 생성자와 Getter 추가
-    public MemberListResponseDto(List<MemberResponseDto> members, long totalElements, int totalPages) {
-        this.members = members;
-        this.totalElements = totalElements;
-        this.totalPages = totalPages;
-    }
+        PageMetaResponse meta = PageMetaResponse.fromPage(page);
 
-    public List<MemberResponseDto> getMembers() {
-        return members;
-    }
-
-    public long getTotalElements() {
-        return totalElements;
-    }
-
-    public int getTotalPages() {
-        return totalPages;
+        return new MemberListResponseDto(memberDtos, meta);
     }
 }

--- a/module-service/src/main/java/com/checkping/dto/member/response/MemberListResponseDto.java
+++ b/module-service/src/main/java/com/checkping/dto/member/response/MemberListResponseDto.java
@@ -6,14 +6,15 @@ import lombok.Getter;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
 public class MemberListResponseDto {
 
     private final List<MemberResponseDto> members;
-    private final PageMetaResponse meta;
+    private final Map<String, Object> meta;
 
-    public MemberListResponseDto(List<MemberResponseDto> members, PageMetaResponse meta) {
+    public MemberListResponseDto(List<MemberResponseDto> members, Map<String, Object> meta) {
         this.members = members;
         this.meta = meta;
     }
@@ -24,7 +25,8 @@ public class MemberListResponseDto {
                 .toList();
 
         PageMetaResponse meta = PageMetaResponse.fromPage(page);
+        Map<String, Object> result =  meta.toMap();
 
-        return new MemberListResponseDto(memberDtos, meta);
+        return new MemberListResponseDto(memberDtos, result);
     }
 }

--- a/module-service/src/main/java/com/checkping/dto/member/response/MemberListResponseDto.java
+++ b/module-service/src/main/java/com/checkping/dto/member/response/MemberListResponseDto.java
@@ -1,6 +1,6 @@
 package com.checkping.dto.member.response;
 
-import com.checkping.common.response.PageMetaResponse;
+import com.checkping.common.dto.PageMetaResponse;
 import com.checkping.domain.member.Member;
 import lombok.Getter;
 import org.springframework.data.domain.Page;

--- a/module-service/src/main/java/com/checkping/service/member/MemberService.java
+++ b/module-service/src/main/java/com/checkping/service/member/MemberService.java
@@ -44,11 +44,6 @@ public class MemberService {
         return MemberResponseDto.fromEntity(member);
     }
 
-    //모든 회원 목록 조회
-//    public MemberListResponseDto getAllMemberListAsDto() {
-//        List<Member> members = memberRepository.findAll();
-//        return MemberListResponseDto.fromEntityList(members);
-//    }
     // 페이징된 전체 회원 목록 조회
     public MemberListResponseDto getAllMembersWithPaging(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);


### PR DESCRIPTION
# 🚀 Pull Request

 멤버 페이징 기능 구현

## #️⃣ 연관된 이슈

#197

## 📋 작업 내용
   - MemberListResponseDto에 'meta' 필드를 추가하여 페이징 관련 메타데이터 반환 기능 구현
    - totalElements, isFirstPage, isLastPage, totalPages, pageSize, currentPage 정보 포함
    - 공통적으로 사용하는 meta 데이터를 관리하기 위해 MetaResponse 클래스 생성
    - totalElements, isFirstPage, isLastPage, totalPages, pageSize, currentPage 포함
    - Page 객체를 기반으로 MetaResponse 생성 가능 (fromPage 메서드)
    - meta 데이터를 Map으로 변환하는 toMap 메서드 추가

