### PR TITLE
Feat 241 JWT 토큰 저장 위치 변경

### DIFF
--- a/module-api/src/main/java/com/checkping/api/auth/config/CustomSecurityConfig.java
+++ b/module-api/src/main/java/com/checkping/api/auth/config/CustomSecurityConfig.java
@@ -2,6 +2,7 @@ package com.checkping.api.auth.config;
 
 
 import com.checkping.api.auth.filter.CustomLogoutFilter;
+import com.checkping.api.auth.filter.JWTFilter;
 import com.checkping.api.auth.filter.LoginFilter;
 import com.checkping.service.member.util.JwtUtil;
 import java.util.List;

--- a/module-api/src/main/java/com/checkping/api/auth/filter/CustomLogoutFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/CustomLogoutFilter.java
@@ -1,7 +1,7 @@
 package com.checkping.api.auth.filter;
 
+import com.checkping.exception.auth.RefreshTokenNotFoundException;
 import com.checkping.service.member.util.JwtUtil;
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -47,29 +47,19 @@ public class CustomLogoutFilter extends GenericFilterBean {
         //get refresh token
         String refresh = null;
         Cookie[] cookies = request.getCookies();
-        for (Cookie cookie : cookies) {
-
-            if (cookie.getName().equals("refresh")) {
-
-                refresh = cookie.getValue();
+        if (cookies != null) { // 쿠키가 null인지 확인
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("refresh")) {
+                    refresh = cookie.getValue();
+                }
             }
         }
 
         //refresh null check
         if (refresh == null) {
 
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            return;
-        }
-
-        //expired check
-        try {
-            jwtUtil.isExpired(refresh);
-        } catch (ExpiredJwtException e) {
-
-            //response status code
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            return;
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            throw new RefreshTokenNotFoundException();
         }
 
         // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
@@ -84,11 +74,17 @@ public class CustomLogoutFilter extends GenericFilterBean {
         //로그아웃 진행
 
         // Refresh 토큰 Cookie 값 0
-        Cookie cookie = new Cookie("refresh", null);
-        cookie.setMaxAge(0);
-        cookie.setPath("/");
+        Cookie refreshCookie = new Cookie("refresh", null);
+        refreshCookie.setMaxAge(0);
+        refreshCookie.setPath("/");
 
-        response.addCookie(cookie);
+        response.addCookie(refreshCookie);
+
+        Cookie accessCookie = new Cookie("access", null);
+        accessCookie.setMaxAge(0);
+        accessCookie.setPath("/");
+
+        response.addCookie(accessCookie);
         response.setStatus(HttpServletResponse.SC_OK);
     }
 }

--- a/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
@@ -4,12 +4,13 @@ package com.checkping.api.auth.filter;
 import com.checkping.api.auth.util.ResponseUtil;
 import com.checkping.common.enums.ErrorCode;
 import com.checkping.common.response.BaseResponse;
+import com.checkping.exception.auth.AccessTokenNotFoundException;
 import com.checkping.service.member.util.JwtUtil;
 import com.checkping.service.member.auth.CustomUserDetails;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
@@ -19,8 +20,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.Map;
 
 public class JWTFilter extends OncePerRequestFilter {
 
@@ -48,12 +47,12 @@ public class JWTFilter extends OncePerRequestFilter {
         if (request.getRequestURI().startsWith(("/reissue"))) {
             return true;
         }
-        
+
         // 회원 생성 시 필터 제외
         if (request.getRequestURI().equals("/admins/members")){
             return true;
         }
-        
+
         // 업체 생성시 필터 제외
         if (request.getRequestURI().equals("/admins/organizations")){
             return true;
@@ -74,19 +73,28 @@ public class JWTFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        // 헤더에서 access키에 담긴 토큰을 꺼내서 Bearer를 제거 후 accessToken에 담음
-        String authorizationHeader = request.getHeader("Authorization");
+        // 쿠키에서 토큰 추출
+        Cookie[] cookies = request.getCookies();
 
-        // 헤더에 토큰이 없거나 Bearer로 시작하지 않는 경우
-        if(authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+        // 쿠키가 없는 경우
+        if (cookies == null) {
 
-            // 실패 응답 생성 (BaseResponse 활용)
             BaseResponse<Void> errorResponse = BaseResponse.fail(ErrorCode.UNAUTHORIZED);
             ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
             return;
         }
 
-        String accessToken = authorizationHeader.substring(7);
+        // access 토큰 추출
+        Cookie cookie = null;
+
+        for (Cookie c : cookies) {
+            if ("access".equals(c.getName())) {
+                cookie = c;
+                break;
+            }
+        }
+
+        String accessToken = cookie.getValue();
 
 
         // 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음

--- a/module-api/src/main/java/com/checkping/api/auth/util/ResponseUtil.java
+++ b/module-api/src/main/java/com/checkping/api/auth/util/ResponseUtil.java
@@ -15,7 +15,7 @@ public class ResponseUtil {
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge(24*60*60);
         //cookie.setSecure(true);
-        //cookie.setPath("/");
+        cookie.setPath("/");
         cookie.setHttpOnly(true);
 
         return cookie;
@@ -42,7 +42,7 @@ public class ResponseUtil {
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         response.setStatus(status.value());
-        response.setHeader("Authorization", "Bearer " + accessToken);
+        response.addCookie(createCookie("access", accessToken));
         response.addCookie(createCookie("refresh", refreshToken));
         response.getWriter().write(objectMapper.writeValueAsString(successResponse));
     }

--- a/module-api/src/main/java/com/checkping/api/controller/ReissueController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/ReissueController.java
@@ -37,7 +37,7 @@ public class ReissueController {
         String newRefresh = reissueService.generateRefreshToken(name, email, role);
 
         // Set response
-        response.setHeader("Authorization", "Bearer " + newAccess);
+        response.addCookie(ResponseUtil.createCookie("access", newAccess));
         response.addCookie(ResponseUtil.createCookie("refresh", newRefresh));
 
         return BaseResponse.success("Reissue success");

--- a/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
+++ b/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
@@ -21,6 +21,8 @@ public enum ErrorCode {
     INVALID_JWT_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Access Token입니다."),
     EXPIRED_JWT_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "Access Token이 만료되었습니다. 재발급 받으세요."),
     INVALID_JWT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다."),
+    ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Access Token을 찾을 수 없습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Refresh Token을 찾을 수 없습니다."),
     EXPIRED_JWT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token이 만료되었습니다. 다시 로그인하세요."),
     INVALID_LOGIN_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일(로그인 전용 이메일) 또는 비밀번호를 잘못 입력했습니다." + "입력하신 내용을 다시 확인해주세요."),
 

--- a/module-service/src/main/java/com/checkping/exception/auth/AccessTokenNotFoundException.java
+++ b/module-service/src/main/java/com/checkping/exception/auth/AccessTokenNotFoundException.java
@@ -1,0 +1,10 @@
+package com.checkping.exception.auth;
+
+import com.checkping.common.enums.ErrorCode;
+
+public class AccessTokenNotFoundException extends TokenException {
+
+    public AccessTokenNotFoundException() {
+        super("Access Token을 찾을 수 없습니다.", ErrorCode.ACCESS_TOKEN_NOT_FOUND);
+    }
+}

--- a/module-service/src/main/java/com/checkping/exception/auth/RefreshTokenNotFoundException.java
+++ b/module-service/src/main/java/com/checkping/exception/auth/RefreshTokenNotFoundException.java
@@ -5,6 +5,6 @@ import com.checkping.common.enums.ErrorCode;
 public class RefreshTokenNotFoundException extends TokenException {
 
     public RefreshTokenNotFoundException() {
-        super("Refresh Token을 찾을 수 없습니다.", ErrorCode.INVALID_JWT_REFRESH_TOKEN);
+        super("Refresh Token을 찾을 수 없습니다.", ErrorCode.REFRESH_TOKEN_NOT_FOUND);
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

JWT 토큰 저장 위치 변경 (엑세스 토큰 : 헤더 -> 쿠키)

## #️⃣ 연관된 이슈

#Issue: 241

## 📋 작업 내용

feat: JWT 토큰 저장 위치 변경
- AccessTokenNotFound 예외 추가
- RefreshTokenNotFoundException 예외 추가
- ResponseUtil : 엑세스 토큰을 쿠키에 저장하도록 변경
= ReissueController : 엑세스 토큰을 쿠키에 저장하도록 변경
- JWTFilter : 쿠키에서 엑세스 토큰을 찾아 검증하도록 수정
- ErrorCode : ACCESS_TOKEN_NOT_FOUND, REFRESH_TOKEN_NOT_FOUND 추가
- CustomLogoutFilter : 엑세스 토큰도 쿠키에서 삭제하도록 수정
