### PR TITLE
Feature/210 feature 질문 게시글 생성 api 수정 및 연동

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/project/QuestionApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/project/QuestionApi.java
@@ -1,7 +1,7 @@
 package com.checkping.api.controller.project;
 
 import com.checkping.common.response.BaseResponse;
-import com.checkping.dto.question.QuestionRegister.Request;
+import com.checkping.dto.question.QuestionRegister;
 import com.checkping.dto.question.QuestionRequest;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
 import com.checkping.dto.question.QuestionResponse.QuestionListDto;
@@ -9,12 +9,8 @@ import com.checkping.dto.question.comment.QuestionCommentRequest;
 import com.checkping.dto.question.comment.QuestionCommentResponse.QuestionCommentDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
-import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.multipart.MultipartFile;
 
 
 @Tag(name = "Question API(QuestionController)", description = "질문 게시판 API 입니다.")
@@ -22,8 +18,7 @@ public interface QuestionApi {
 
     @Operation(summary = "질문 게시글 등록", description = "질문 게시글을 등록하는 기능입니다.")
     BaseResponse<QuestionItemDto> register(
-        @Parameter(description = "등록 게시글 정보", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) @RequestPart(value = "content") Request request,
-        @Parameter(description = "등록 첨부 파일", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)) @RequestPart(required = false, value = "fileList") List<MultipartFile> fileList);
+        @Parameter(description = "등록 게시글 정보") QuestionRegister.Request request);
 
     @Operation(summary = "질문 게시글 목록 조회", description = "질문 게시글 목록을 조회하는 기능입니다.")
     BaseResponse<List<QuestionListDto>> getQuestionList(

--- a/module-api/src/main/java/com/checkping/api/controller/project/QuestionApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/project/QuestionApi.java
@@ -1,10 +1,11 @@
 package com.checkping.api.controller.project;
 
 import com.checkping.common.response.BaseResponse;
-import com.checkping.dto.question.QuestionResponse.QuestionListDto;
-import com.checkping.dto.question.comment.QuestionCommentRequest;
+import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
+import com.checkping.dto.question.QuestionResponse.QuestionListDto;
+import com.checkping.dto.question.comment.QuestionCommentRequest;
 import com.checkping.dto.question.comment.QuestionCommentResponse.QuestionCommentDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,7 +22,7 @@ public interface QuestionApi {
 
     @Operation(summary = "질문 게시글 등록", description = "질문 게시글을 등록하는 기능입니다.")
     BaseResponse<QuestionItemDto> register(
-        @Parameter(description = "등록 게시글 정보", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) @RequestPart(value = "content") QuestionRequest.RegisterDto request,
+        @Parameter(description = "등록 게시글 정보", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) @RequestPart(value = "content") Request request,
         @Parameter(description = "등록 첨부 파일", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)) @RequestPart(required = false, value = "fileList") List<MultipartFile> fileList);
 
     @Operation(summary = "질문 게시글 목록 조회", description = "질문 게시글 목록을 조회하는 기능입니다.")

--- a/module-api/src/main/java/com/checkping/api/controller/project/QuestionApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/project/QuestionApi.java
@@ -2,10 +2,11 @@ package com.checkping.api.controller.project;
 
 import com.checkping.common.response.BaseResponse;
 import com.checkping.dto.question.QuestionRegister.Request;
-import com.checkping.dto.question.QuestionRequest;
+import com.checkping.dto.question.QuestionRequest.UpdateDto;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
 import com.checkping.dto.question.QuestionResponse.QuestionListDto;
 import com.checkping.dto.question.comment.QuestionCommentRequest;
+import com.checkping.dto.question.comment.QuestionCommentRequest.RegisterDto;
 import com.checkping.dto.question.comment.QuestionCommentResponse.QuestionCommentDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -23,33 +24,40 @@ public interface QuestionApi {
 
     @Operation(summary = "질문 게시글 목록 조회", description = "질문 게시글 목록을 조회하는 기능입니다.")
     BaseResponse<List<QuestionListDto>> getQuestionList(
+        @Parameter(description = "프로젝트 ID") Long projectId,
         @Parameter(description = "게시글 유형 - null 가능") String category,
         @Parameter(description = "게시글 상태 - null 가능") String status,
         @Parameter(description = "게시글 검색어") String keyword);
 
     @Operation(summary = "질문 게시글 상세 조회", description = "질문 게시글을 조회하는 기능입니다.")
-    BaseResponse<QuestionItemDto> getQuestion(@Parameter(description = "게시글 ID") Long questionId);
+    BaseResponse<QuestionItemDto> getQuestion(@Parameter(description = "프로젝트 ID") Long projectId,
+        @Parameter(description = "게시글 ID") Long questionId);
 
     @Operation(summary = "질문 게시글 수정", description = "질문 게시글을 수정하는 기능입니다.")
-    BaseResponse<QuestionItemDto> updateQuestion(@Parameter(description = "게시글 ID") Long questionId,
-        @Parameter(description = "게시글 수정 정보 Dto") QuestionRequest.UpdateDto request);
+    BaseResponse<QuestionItemDto> updateQuestion(@Parameter(description = "프로젝트 ID") Long projectId,
+        @Parameter(description = "게시글 ID") Long questionId,
+        @Parameter(description = "게시글 수정 정보 Dto") UpdateDto request);
 
     @Operation(summary = "질문 게시글 소프트 삭제", description = "질문 게시글을 약한 삭제를 하는 기능입니다..")
     BaseResponse<QuestionListDto> deleteSoftQuestion(
+        @Parameter(description = "프로젝트 ID") Long projectId,
         @Parameter(description = "게시글 ID") Long questionId);
 
     @Operation(summary = "질문 게시글 댓글 등록", description = "질문 게시글의 댓글을 등록하는 기능입니다.")
     BaseResponse<QuestionCommentDto> registerComment(
+        @Parameter(description = "프로젝트 ID") Long projectId,
         @Parameter(description = "게시글 ID") Long questionId,
-        @Parameter(description = "게시글 댓글 등록 Dto") QuestionCommentRequest.RegisterDto request);
+        @Parameter(description = "게시글 댓글 등록 Dto") RegisterDto request);
 
     @Operation(summary = "질문 게시글 댓글 소프트 삭제", description = "질문 게시글의 댓글을 소프트 삭제하는 기능입니다.")
     BaseResponse<QuestionCommentDto> deleteSoftComment(
+        @Parameter(description = "프로젝트 ID") Long projectId,
         @Parameter(description = "게시글 ID") Long questionId,
         @Parameter(description = "게시글 댓글 ID") Long commentId);
 
     @Operation(summary = "질문 게시글 댓글 수정", description = "질문 게시글의 댓글을 수정하는 기능입니다.")
     BaseResponse<QuestionCommentDto> updateComment(
+        @Parameter(description = "프로젝트 ID") Long projectId,
         @Parameter(description = "게시글 ID") Long questionId,
         @Parameter(description = "게시글 댓글 ID") Long commentId,
         @Parameter(description = "게시글 댓글 수정 Dto") QuestionCommentRequest.UpdateDto request);

--- a/module-api/src/main/java/com/checkping/api/controller/project/QuestionApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/project/QuestionApi.java
@@ -1,7 +1,7 @@
 package com.checkping.api.controller.project;
 
 import com.checkping.common.response.BaseResponse;
-import com.checkping.dto.question.QuestionRegister;
+import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
 import com.checkping.dto.question.QuestionResponse.QuestionListDto;
@@ -18,7 +18,8 @@ public interface QuestionApi {
 
     @Operation(summary = "질문 게시글 등록", description = "질문 게시글을 등록하는 기능입니다.")
     BaseResponse<QuestionItemDto> register(
-        @Parameter(description = "등록 게시글 정보") QuestionRegister.Request request);
+        @Parameter(description = "프로젝트 ID") Long projectId,
+        @Parameter(description = "등록 게시글 정보") Request request);
 
     @Operation(summary = "질문 게시글 목록 조회", description = "질문 게시글 목록을 조회하는 기능입니다.")
     BaseResponse<List<QuestionListDto>> getQuestionList(

--- a/module-api/src/main/java/com/checkping/api/controller/project/QuestionApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/project/QuestionApi.java
@@ -1,6 +1,7 @@
 package com.checkping.api.controller.project;
 
 import com.checkping.common.response.BaseResponse;
+import com.checkping.dto.question.QuestionRegister;
 import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest.UpdateDto;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
@@ -18,7 +19,7 @@ import java.util.List;
 public interface QuestionApi {
 
     @Operation(summary = "질문 게시글 등록", description = "질문 게시글을 등록하는 기능입니다.")
-    BaseResponse<QuestionItemDto> register(
+    BaseResponse<QuestionRegister.Response> register(
         @Parameter(description = "프로젝트 ID") Long projectId,
         @Parameter(description = "등록 게시글 정보") Request request);
 

--- a/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
@@ -1,7 +1,7 @@
 package com.checkping.api.controller.project;
 
 import com.checkping.common.response.BaseResponse;
-import com.checkping.dto.question.QuestionRegister;
+import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest;
 import com.checkping.dto.question.QuestionRequest.SearchCondition;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
@@ -19,11 +19,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
+@RequestMapping("/project/{projectId}")
 @RequiredArgsConstructor
 public class QuestionController implements QuestionApi {
 
@@ -33,10 +35,9 @@ public class QuestionController implements QuestionApi {
     @PostMapping(value = "/question")
     @Override
     public BaseResponse<QuestionItemDto> register(
-        @RequestBody QuestionRegister.Request request) {
+        @PathVariable Long projectId, @RequestBody Request request) {
 
-
-        QuestionItemDto taskBoardDto = questionService.register(request);
+        QuestionItemDto taskBoardDto = questionService.register(projectId, request);
 
         return BaseResponse.success(taskBoardDto);
     }

--- a/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
@@ -1,6 +1,7 @@
 package com.checkping.api.controller.project;
 
 import com.checkping.common.response.BaseResponse;
+import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest;
 import com.checkping.dto.question.QuestionRequest.SearchCondition;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
@@ -36,7 +37,7 @@ public class QuestionController implements QuestionApi {
         MediaType.MULTIPART_FORM_DATA_VALUE})
     @Override
     public BaseResponse<QuestionItemDto> register(
-        @RequestPart(value = "content") QuestionRequest.RegisterDto request,
+        @RequestPart(value = "content") Request request,
         @RequestPart(required = false, value = "fileList") List<MultipartFile> fileList) {
 
         QuestionItemDto taskBoardDto = questionService.register(request, fileList);

--- a/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
@@ -25,14 +25,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/project/{projectId}")
+@RequestMapping("/projects/{projectId}")
 @RequiredArgsConstructor
 public class QuestionController implements QuestionApi {
 
     private final QuestionService questionService;
     private final QuestionCommentService questionCommentService;
 
-    @PostMapping(value = "/question")
+    @PostMapping(value = "/questions")
     @Override
     public BaseResponse<QuestionItemDto> register(
         @PathVariable Long projectId, @RequestBody Request request) {
@@ -42,7 +42,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(taskBoardDto);
     }
 
-    @GetMapping("/question")
+    @GetMapping("/questions")
     @Override
     public BaseResponse<List<QuestionListDto>> getQuestionList(
         @RequestParam(required = false) String category,
@@ -60,7 +60,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(questionListDtoList);
     }
 
-    @GetMapping("/question/{questionId}")
+    @GetMapping("/questions/{questionId}")
     @Override
     public BaseResponse<QuestionItemDto> getQuestion(@PathVariable Long questionId) {
 
@@ -69,7 +69,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(questionItemDto);
     }
 
-    @PutMapping("/question/{questionId}")
+    @PutMapping("/questions/{questionId}")
     @Override
     public BaseResponse<QuestionItemDto> updateQuestion(@PathVariable Long questionId,
         @RequestBody QuestionRequest.UpdateDto request) {
@@ -80,7 +80,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(updatedBoardDto);
     }
 
-    @DeleteMapping("/question/{questionId}")
+    @DeleteMapping("/questions/{questionId}")
     @Override
     public BaseResponse<QuestionListDto> deleteSoftQuestion(
         @PathVariable Long questionId) {
@@ -90,7 +90,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(deletedBoardDto);
     }
 
-    @PostMapping("/question/{questionId}/comments")
+    @PostMapping("/questions/{questionId}/comments")
     @Override
     public BaseResponse<QuestionCommentDto> registerComment(
         @PathVariable Long questionId, @RequestBody QuestionCommentRequest.RegisterDto request) {
@@ -101,7 +101,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(questionCommentDto);
     }
 
-    @DeleteMapping("/question/{questionId}/comments/{commentId}")
+    @DeleteMapping("/questions/{questionId}/comments/{commentId}")
     @Override
     public BaseResponse<QuestionCommentDto> deleteSoftComment(
         @PathVariable Long questionId, @PathVariable Long commentId) {
@@ -112,7 +112,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(deletedCommentDto);
     }
 
-    @PutMapping("/question/{questionId}/comments/{commentId}")
+    @PutMapping("/questions/{questionId}/comments/{commentId}")
     @Override
     public BaseResponse<QuestionCommentDto> updateComment(
         @PathVariable Long questionId, @PathVariable Long commentId,

--- a/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
@@ -1,6 +1,7 @@
 package com.checkping.api.controller.project;
 
 import com.checkping.common.response.BaseResponse;
+import com.checkping.dto.question.QuestionRegister;
 import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest;
 import com.checkping.dto.question.QuestionRequest.SearchCondition;
@@ -36,12 +37,12 @@ public class QuestionController implements QuestionApi {
 
     @PostMapping(value = "/questions")
     @Override
-    public BaseResponse<QuestionItemDto> register(
+    public BaseResponse<QuestionRegister.Response> register(
         @PathVariable Long projectId, @RequestBody Request request) {
 
-        QuestionItemDto taskBoardDto = questionService.register(projectId, request);
+        QuestionRegister.Response response = questionService.register(projectId, request);
 
-        return BaseResponse.success(taskBoardDto);
+        return BaseResponse.success(response);
     }
 
     @GetMapping("/questions")

--- a/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
@@ -1,7 +1,7 @@
 package com.checkping.api.controller.project;
 
 import com.checkping.common.response.BaseResponse;
-import com.checkping.dto.question.QuestionRegister.Request;
+import com.checkping.dto.question.QuestionRegister;
 import com.checkping.dto.question.QuestionRequest;
 import com.checkping.dto.question.QuestionRequest.SearchCondition;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
@@ -13,7 +13,6 @@ import com.checkping.service.question.comment.QuestionCommentService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,9 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -33,14 +30,13 @@ public class QuestionController implements QuestionApi {
     private final QuestionService questionService;
     private final QuestionCommentService questionCommentService;
 
-    @PostMapping(value = "/question", consumes = {MediaType.APPLICATION_JSON_VALUE,
-        MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = "/question")
     @Override
     public BaseResponse<QuestionItemDto> register(
-        @RequestPart(value = "content") Request request,
-        @RequestPart(required = false, value = "fileList") List<MultipartFile> fileList) {
+        @RequestBody QuestionRegister.Request request) {
 
-        QuestionItemDto taskBoardDto = questionService.register(request, fileList);
+
+        QuestionItemDto taskBoardDto = questionService.register(request);
 
         return BaseResponse.success(taskBoardDto);
     }

--- a/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
@@ -4,9 +4,11 @@ import com.checkping.common.response.BaseResponse;
 import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest;
 import com.checkping.dto.question.QuestionRequest.SearchCondition;
+import com.checkping.dto.question.QuestionRequest.UpdateDto;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
 import com.checkping.dto.question.QuestionResponse.QuestionListDto;
 import com.checkping.dto.question.comment.QuestionCommentRequest;
+import com.checkping.dto.question.comment.QuestionCommentRequest.RegisterDto;
 import com.checkping.dto.question.comment.QuestionCommentResponse.QuestionCommentDto;
 import com.checkping.service.question.QuestionService;
 import com.checkping.service.question.comment.QuestionCommentService;
@@ -45,7 +47,7 @@ public class QuestionController implements QuestionApi {
     @GetMapping("/questions")
     @Override
     public BaseResponse<List<QuestionListDto>> getQuestionList(
-        @RequestParam(required = false) String category,
+        @PathVariable Long projectId, @RequestParam(required = false) String category,
         @RequestParam(required = false) String status,
         @RequestParam(required = false) String keyword) {
 
@@ -62,7 +64,8 @@ public class QuestionController implements QuestionApi {
 
     @GetMapping("/questions/{questionId}")
     @Override
-    public BaseResponse<QuestionItemDto> getQuestion(@PathVariable Long questionId) {
+    public BaseResponse<QuestionItemDto> getQuestion(@PathVariable Long projectId,
+        @PathVariable Long questionId) {
 
         QuestionItemDto questionItemDto = questionService.getQuestionById(questionId);
 
@@ -71,8 +74,9 @@ public class QuestionController implements QuestionApi {
 
     @PutMapping("/questions/{questionId}")
     @Override
-    public BaseResponse<QuestionItemDto> updateQuestion(@PathVariable Long questionId,
-        @RequestBody QuestionRequest.UpdateDto request) {
+    public BaseResponse<QuestionItemDto> updateQuestion(Long projectId,
+        @PathVariable Long questionId,
+        @RequestBody UpdateDto request) {
 
         QuestionItemDto updatedBoardDto = questionService.update(questionId,
             request);
@@ -83,7 +87,7 @@ public class QuestionController implements QuestionApi {
     @DeleteMapping("/questions/{questionId}")
     @Override
     public BaseResponse<QuestionListDto> deleteSoftQuestion(
-        @PathVariable Long questionId) {
+        @PathVariable Long projectId, @PathVariable Long questionId) {
 
         QuestionListDto deletedBoardDto = questionService.deleteSoft(questionId);
 
@@ -93,7 +97,8 @@ public class QuestionController implements QuestionApi {
     @PostMapping("/questions/{questionId}/comments")
     @Override
     public BaseResponse<QuestionCommentDto> registerComment(
-        @PathVariable Long questionId, @RequestBody QuestionCommentRequest.RegisterDto request) {
+        @PathVariable Long projectId, @PathVariable Long questionId,
+        @RequestBody RegisterDto request) {
 
         QuestionCommentDto questionCommentDto = questionCommentService.register(
             questionId, request);
@@ -104,7 +109,7 @@ public class QuestionController implements QuestionApi {
     @DeleteMapping("/questions/{questionId}/comments/{commentId}")
     @Override
     public BaseResponse<QuestionCommentDto> deleteSoftComment(
-        @PathVariable Long questionId, @PathVariable Long commentId) {
+        @PathVariable Long projectId, @PathVariable Long questionId, @PathVariable Long commentId) {
 
         QuestionCommentDto deletedCommentDto = questionCommentService.deleteSoft(
             questionId, commentId);
@@ -115,7 +120,7 @@ public class QuestionController implements QuestionApi {
     @PutMapping("/questions/{questionId}/comments/{commentId}")
     @Override
     public BaseResponse<QuestionCommentDto> updateComment(
-        @PathVariable Long questionId, @PathVariable Long commentId,
+        @PathVariable Long projectId, @PathVariable Long questionId, @PathVariable Long commentId,
         @RequestBody QuestionCommentRequest.UpdateDto request) {
 
         QuestionCommentDto updatedCommentDto = questionCommentService.update(

--- a/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/project/QuestionController.java
@@ -28,14 +28,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/projects/{projectId}")
+@RequestMapping("/projects/{projectId}/questions")
 @RequiredArgsConstructor
 public class QuestionController implements QuestionApi {
 
     private final QuestionService questionService;
     private final QuestionCommentService questionCommentService;
 
-    @PostMapping(value = "/questions")
+    @PostMapping
     @Override
     public BaseResponse<QuestionRegister.Response> register(
         @PathVariable Long projectId, @RequestBody Request request) {
@@ -45,7 +45,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(response);
     }
 
-    @GetMapping("/questions")
+    @GetMapping
     @Override
     public BaseResponse<List<QuestionListDto>> getQuestionList(
         @PathVariable Long projectId, @RequestParam(required = false) String category,
@@ -63,7 +63,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(questionListDtoList);
     }
 
-    @GetMapping("/questions/{questionId}")
+    @GetMapping("/{questionId}")
     @Override
     public BaseResponse<QuestionItemDto> getQuestion(@PathVariable Long projectId,
         @PathVariable Long questionId) {
@@ -73,7 +73,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(questionItemDto);
     }
 
-    @PutMapping("/questions/{questionId}")
+    @PutMapping("/{questionId}")
     @Override
     public BaseResponse<QuestionItemDto> updateQuestion(Long projectId,
         @PathVariable Long questionId,
@@ -85,7 +85,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(updatedBoardDto);
     }
 
-    @DeleteMapping("/questions/{questionId}")
+    @DeleteMapping("/{questionId}")
     @Override
     public BaseResponse<QuestionListDto> deleteSoftQuestion(
         @PathVariable Long projectId, @PathVariable Long questionId) {
@@ -95,7 +95,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(deletedBoardDto);
     }
 
-    @PostMapping("/questions/{questionId}/comments")
+    @PostMapping("/{questionId}/comments")
     @Override
     public BaseResponse<QuestionCommentDto> registerComment(
         @PathVariable Long projectId, @PathVariable Long questionId,
@@ -107,7 +107,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(questionCommentDto);
     }
 
-    @DeleteMapping("/questions/{questionId}/comments/{commentId}")
+    @DeleteMapping("/{questionId}/comments/{commentId}")
     @Override
     public BaseResponse<QuestionCommentDto> deleteSoftComment(
         @PathVariable Long projectId, @PathVariable Long questionId, @PathVariable Long commentId) {
@@ -118,7 +118,7 @@ public class QuestionController implements QuestionApi {
         return BaseResponse.success(deletedCommentDto);
     }
 
-    @PutMapping("/questions/{questionId}/comments/{commentId}")
+    @PutMapping("/{questionId}/comments/{commentId}")
     @Override
     public BaseResponse<QuestionCommentDto> updateComment(
         @PathVariable Long projectId, @PathVariable Long questionId, @PathVariable Long commentId,

--- a/module-domain/src/main/java/com/checkping/domain/question/Question.java
+++ b/module-domain/src/main/java/com/checkping/domain/question/Question.java
@@ -40,7 +40,6 @@ public class Question extends BaseEntity {
     content : 게시글 본문
     regAt : 작성 일시
     editAt : 수정 일시
-    approverAt : 승인 일시
     category : 게시글 유형
     status : 게시글 상태
     deletedYn : 삭제 여부
@@ -72,9 +71,6 @@ public class Question extends BaseEntity {
     @LastModifiedDate
     @Column(name = "edit_at")
     private LocalDateTime editAt;
-
-    @Column(name = "approver_at")
-    private LocalDateTime approverAt;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "category", nullable = false, length = 100)

--- a/module-domain/src/main/java/com/checkping/domain/question/Question.java
+++ b/module-domain/src/main/java/com/checkping/domain/question/Question.java
@@ -2,8 +2,6 @@ package com.checkping.domain.question;
 
 import com.checkping.domain.BaseEntity;
 import com.checkping.domain.member.Member;
-import com.checkping.domain.project.ProgressStep;
-import com.checkping.domain.project.Project;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -94,23 +92,21 @@ public class Question extends BaseEntity {
     @JoinColumn(name = "parent_id")
     private Question parent;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "register_id", nullable = false)
-    private Member register;
+    // TODO : Member register 로 변경할 것
+    private Long registerId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "updater_id")
     private Member updater;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "project_id", nullable = false, updatable = false)
-    @JoinColumn(name = "project_id", updatable = false)
-    private Project project;
+    // TODO  : Member updater 로 변경할 것
+    private Long updaterId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "progress_step_id", nullable = false)
-    @JoinColumn(name = "progress_step_id")
-    private ProgressStep progressStep;
+    // TODO : Project project 로 변경할 것
+    private Long projectId;
+
+    // TODO : ProgressStep progressStep 로 변경할 것
+    private Long progressStepId;
 
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
     private List<QuestionComment> commentList = new ArrayList<>();
@@ -215,7 +211,7 @@ public class Question extends BaseEntity {
     }
 
     // Contained Project
-    public void containedProject(Project project) {
-        this.project = project;
+    public void containedProject(Long projectId) {
+        this.projectId = projectId;
     }
 }

--- a/module-domain/src/main/java/com/checkping/domain/question/Question.java
+++ b/module-domain/src/main/java/com/checkping/domain/question/Question.java
@@ -104,11 +104,13 @@ public class Question extends BaseEntity {
     private Member updater;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id", nullable = false)
+//    @JoinColumn(name = "project_id", nullable = false, updatable = false)
+    @JoinColumn(name = "project_id", updatable = false)
     private Project project;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "progress_step_id", nullable = false)
+//    @JoinColumn(name = "progress_step_id", nullable = false)
+    @JoinColumn(name = "progress_step_id")
     private ProgressStep progressStep;
 
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
@@ -202,5 +204,10 @@ public class Question extends BaseEntity {
             // Add QuestionFile
             addFile(file);
         }
+    }
+
+    // Contained Project
+    public void containedProject(Project project) {
+        this.project = project;
     }
 }

--- a/module-domain/src/main/java/com/checkping/domain/question/Question.java
+++ b/module-domain/src/main/java/com/checkping/domain/question/Question.java
@@ -1,6 +1,9 @@
 package com.checkping.domain.question;
 
 import com.checkping.domain.BaseEntity;
+import com.checkping.domain.member.Member;
+import com.checkping.domain.project.ProgressStep;
+import com.checkping.domain.project.Project;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -26,7 +29,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
-@ToString(exclude = "commentList")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -46,6 +48,10 @@ public class Question extends BaseEntity {
     status : 게시글 상태
     deletedYn : 삭제 여부
     parent : 부모 게시글
+    register : 작성자 (register_id)
+    updater : 수정자 (updater_id)
+    project : 프로젝트 (project_id)
+    progress_step : 진행 단계 (progress_step_id)
      */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -88,6 +94,22 @@ public class Question extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Question parent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "register_id", nullable = false)
+    private Member register;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "updater_id")
+    private Member updater;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "progress_step_id", nullable = false)
+    private ProgressStep progressStep;
 
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
     private List<QuestionComment> commentList = new ArrayList<>();

--- a/module-domain/src/main/java/com/checkping/domain/question/Question.java
+++ b/module-domain/src/main/java/com/checkping/domain/question/Question.java
@@ -95,10 +95,6 @@ public class Question extends BaseEntity {
     // TODO : Member register 로 변경할 것
     private Long registerId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "updater_id")
-    private Member updater;
-
     // TODO  : Member updater 로 변경할 것
     private Long updaterId;
 
@@ -138,6 +134,29 @@ public class Question extends BaseEntity {
     public enum DeleteStatus {
         Y("비활성화"), N("활성화");
         private final String description;
+    }
+
+    /*
+    GENERATE
+     */
+
+    public static Question generate(Long projectId, Long progressStepId, String title,
+        String content, Category category) {
+
+        Question question = new Question();
+        // TODO : 연관관계 맵핑하는 것들 변경할 것
+        question.projectId = projectId;
+        question.progressStepId = progressStepId;
+        question.title = title;
+        question.content = content;
+        question.category = category;
+
+        question.updateCategory(Question.Category.QUESTION);
+        question.updateStatus(Question.Status.WAIT);
+        question.activate();
+
+        return question;
+
     }
 
     // soft delete 적용 = 게시글 비활성화

--- a/module-domain/src/main/java/com/checkping/domain/question/Question.java
+++ b/module-domain/src/main/java/com/checkping/domain/question/Question.java
@@ -24,7 +24,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -182,6 +181,15 @@ public class Question extends BaseEntity {
         // null check & contains check
         if (link != null && !this.questionLinkList.contains(link)) {
             this.questionLinkList.add(link);
+        }
+    }
+
+    // ADD QuestionLink List
+    public void addLink(List<QuestionLink> linkList) {
+        // loop for Add
+        for (QuestionLink link : linkList) {
+            // Add QuestionLink
+            addLink(link);
         }
     }
 

--- a/module-domain/src/main/java/com/checkping/domain/question/Question.java
+++ b/module-domain/src/main/java/com/checkping/domain/question/Question.java
@@ -145,9 +145,8 @@ public class Question extends BaseEntity {
         question.progressStepId = progressStepId;
         question.title = title;
         question.content = content;
-        question.category = category;
 
-        question.updateCategory(Question.Category.QUESTION);
+        question.updateCategory(category);
         question.updateStatus(Question.Status.WAIT);
         question.activate();
 

--- a/module-domain/src/main/java/com/checkping/domain/question/Question.java
+++ b/module-domain/src/main/java/com/checkping/domain/question/Question.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -61,7 +62,8 @@ public class Question extends BaseEntity {
     @Column(name = "title", nullable = false, length = 100)
     private String title;
 
-    @Column(name = "content", nullable = false, length = 5000)
+    @Lob
+    @Column(name = "content", columnDefinition = "TEXT", length = 65536)
     private String content;
 
     @CreatedDate

--- a/module-domain/src/main/java/com/checkping/domain/question/QuestionFile.java
+++ b/module-domain/src/main/java/com/checkping/domain/question/QuestionFile.java
@@ -70,4 +70,17 @@ public class QuestionFile extends BaseEntity {
     public int hashCode() {
         return Objects.hash(id, url, size);
     }
+    
+    /*
+    GENERATE
+     */
+    public static QuestionFile generate(Question question, String originalName, String saveName, String url, long size) {
+        QuestionFile questionFile = new QuestionFile();
+        questionFile.setQuestion(question);
+        questionFile.setOriginalName(originalName);
+        questionFile.setSaveName(saveName);
+        questionFile.setUrl(url);
+        questionFile.setSize(size);
+        return questionFile;
+    }
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectReader.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectReader.java
@@ -1,0 +1,8 @@
+package com.checkping.infra.repository.project;
+
+import com.checkping.domain.project.Project;
+
+public interface ProjectReader {
+
+    Project getById(Long projectId);
+}

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectReaderImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectReaderImpl.java
@@ -1,0 +1,27 @@
+package com.checkping.infra.repository.project;
+
+import com.checkping.common.enums.ErrorCode;
+import com.checkping.common.exception.BaseException;
+import com.checkping.domain.project.Project;
+import com.fasterxml.jackson.databind.ser.Serializers.Base;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectReaderImpl implements ProjectReader {
+
+    private final ProjectRepository projectRepository;
+
+    /**
+     * 프로젝트 ID로 프로젝트 조회
+     *
+     * @param projectId 프로젝트 ID
+     * @return 프로젝트
+     */
+    @Override
+    public Project getById(Long projectId) {
+        return projectRepository.findById(projectId)
+            .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND));
+    }
+}

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileRepository.java
@@ -1,9 +1,9 @@
-package com.checkping.infra.repository.project;
+package com.checkping.infra.repository.question.file;
 
 import com.checkping.domain.question.QuestionFile;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TaskBoardFileRepository extends JpaRepository<QuestionFile, Long> {
+public interface QuestionFileRepository extends JpaRepository<QuestionFile, Long> {
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileStore.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileStore.java
@@ -1,5 +1,6 @@
 package com.checkping.infra.repository.question.file;
 
+import com.checkping.common.utils.FileRequest;
 import com.checkping.domain.question.Question;
 import com.checkping.domain.question.QuestionFile;
 import java.util.List;
@@ -8,4 +9,6 @@ import org.springframework.web.multipart.MultipartFile;
 public interface QuestionFileStore {
 
     List<QuestionFile> saveFileList(Question question, List<MultipartFile> fileList);
+
+    List<QuestionFile> storeFileList(Question question, List<FileRequest> fileList);
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileStore.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileStore.java
@@ -11,4 +11,8 @@ public interface QuestionFileStore {
     List<QuestionFile> saveFileList(Question question, List<MultipartFile> fileList);
 
     List<QuestionFile> storeFileList(Question question, List<FileRequest> fileList);
+
+    QuestionFile store(QuestionFile file);
+
+    List<QuestionFile> store(List<QuestionFile> files);
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileStoreImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileStoreImpl.java
@@ -67,6 +67,16 @@ public class QuestionFileStoreImpl implements QuestionFileStore {
         return questionFileRepository.saveAll(files);
     }
 
+    @Override
+    public QuestionFile store(QuestionFile file) {
+        return questionFileRepository.save(file);
+    }
+
+    @Override
+    public List<QuestionFile> store(List<QuestionFile> files) {
+        return questionFileRepository.saveAll(files);
+    }
+
     private QuestionFile createQuestionFile(Question question, FileRequest request) {
         return QuestionFile.builder()
             .originalName(request.originalName())

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileStoreImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileStoreImpl.java
@@ -54,6 +54,11 @@ public class QuestionFileStoreImpl implements QuestionFileStore {
     @Override
     public List<QuestionFile> storeFileList(Question question, List<FileRequest> fileList) {
 
+        // empty check
+        if (fileList.isEmpty()) {
+            return List.of();
+        }
+
         // File Dto -> Entity
         List<QuestionFile> files = fileList.stream()
             .map(request -> createQuestionFile(question, request))

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileStoreImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileStoreImpl.java
@@ -1,8 +1,8 @@
 package com.checkping.infra.repository.question.file;
 
+import com.checkping.common.utils.FileRequest;
 import com.checkping.domain.question.Question;
 import com.checkping.domain.question.QuestionFile;
-import com.checkping.common.utils.FileRequest;
 import com.checkping.infra.repository.file.FileRepository;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -25,7 +25,7 @@ public class QuestionFileStoreImpl implements QuestionFileStore {
      * QuestionFileStore 첨부 파일 저장
      *
      * @param question 업무 관리 게시글 ID
-     * @param fileList  게시글 첨부 파일 리스트
+     * @param fileList 게시글 첨부 파일 리스트
      * @return List<QuestionFile>
      */
     @Override
@@ -44,8 +44,7 @@ public class QuestionFileStoreImpl implements QuestionFileStore {
     }
 
     /**
-     * QuestionFileStore 첨부 파일 저장
-     * S3 에는 저장하지 않는다.
+     * QuestionFileStore 첨부 파일 저장 S3 에는 저장하지 않는다.
      *
      * @param question 업무 관리 게시글 ID
      * @param fileList 게시글 첨부 파일 리스트
@@ -54,8 +53,8 @@ public class QuestionFileStoreImpl implements QuestionFileStore {
     @Override
     public List<QuestionFile> storeFileList(Question question, List<FileRequest> fileList) {
 
-        // empty check
-        if (fileList.isEmpty()) {
+        // null, empty check
+        if (fileList == null || fileList.isEmpty()) {
             return List.of();
         }
 

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileStoreImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/file/QuestionFileStoreImpl.java
@@ -4,7 +4,6 @@ import com.checkping.domain.question.Question;
 import com.checkping.domain.question.QuestionFile;
 import com.checkping.common.utils.FileRequest;
 import com.checkping.infra.repository.file.FileRepository;
-import com.checkping.infra.repository.project.TaskBoardFileRepository;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -13,12 +12,12 @@ import org.springframework.web.multipart.MultipartFile;
 @Component
 public class QuestionFileStoreImpl implements QuestionFileStore {
 
-    private final TaskBoardFileRepository taskBoardFileRepository;
+    private final QuestionFileRepository questionFileRepository;
     private final FileRepository fileRepository;
 
-    public QuestionFileStoreImpl(TaskBoardFileRepository taskBoardFileRepository,
+    public QuestionFileStoreImpl(QuestionFileRepository questionFileRepository,
         @Qualifier("s3FileRepositoryImpl") FileRepository fileRepository) {
-        this.taskBoardFileRepository = taskBoardFileRepository;
+        this.questionFileRepository = questionFileRepository;
         this.fileRepository = fileRepository;
     }
 
@@ -41,7 +40,27 @@ public class QuestionFileStoreImpl implements QuestionFileStore {
             .toList();
 
         // Save Entity
-        return taskBoardFileRepository.saveAll(files);
+        return questionFileRepository.saveAll(files);
+    }
+
+    /**
+     * QuestionFileStore 첨부 파일 저장
+     * S3 에는 저장하지 않는다.
+     *
+     * @param question 업무 관리 게시글 ID
+     * @param fileList 게시글 첨부 파일 리스트
+     * @return List<QuestionFile> DB 에 저장된 파일 정보 리스트
+     */
+    @Override
+    public List<QuestionFile> storeFileList(Question question, List<FileRequest> fileList) {
+
+        // File Dto -> Entity
+        List<QuestionFile> files = fileList.stream()
+            .map(request -> createQuestionFile(question, request))
+            .toList();
+
+        // Save Entity
+        return questionFileRepository.saveAll(files);
     }
 
     private QuestionFile createQuestionFile(Question question, FileRequest request) {

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/link/QuestionLinkStore.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/link/QuestionLinkStore.java
@@ -1,7 +1,9 @@
 package com.checkping.infra.repository.question.link;
 
 import com.checkping.domain.question.QuestionLink;
+import java.util.List;
 
 public interface QuestionLinkStore {
     QuestionLink store(QuestionLink questionLink);
+    List<QuestionLink> store(List<QuestionLink> questionLinks);
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/link/QuestionLinkStoreImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/link/QuestionLinkStoreImpl.java
@@ -1,6 +1,7 @@
 package com.checkping.infra.repository.question.link;
 
 import com.checkping.domain.question.QuestionLink;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,5 +14,10 @@ public class QuestionLinkStoreImpl implements QuestionLinkStore {
     @Override
     public QuestionLink store(QuestionLink questionLink) {
         return questionLinkRepository.save(questionLink);
+    }
+
+    @Override
+    public List<QuestionLink> store(List<QuestionLink> questionLinks) {
+        return questionLinkRepository.saveAll(questionLinks);
     }
 }

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionContent.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionContent.java
@@ -1,0 +1,25 @@
+package com.checkping.dto.question;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class QuestionContent {
+    /*
+    type : content 타입 (String)
+    data : content 내용 (Object)
+     */
+
+    private String type;
+    private Object data;
+
+    @JsonCreator
+    public QuestionContent(
+        @JsonProperty("type") String type,
+        @JsonProperty("data") Object data) {
+        this.type = type;
+        this.data = data;
+    }
+}

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
@@ -99,7 +99,7 @@ public class QuestionRegister {
         @Schema(description = "게시글 댓글 목록")
         private List<QuestionCommentDto> commentList;
         @Schema(description = "게시글 첨부 링크 목록")
-        private List<QuestionLinkDto> linkList;
+        private List<QuestionLinkRegister.Response> linkList;
         @Schema(description = "게시글 첨부 파일 목록")
         private List<QuestionFileRegister.Response> fileList;
 
@@ -115,6 +115,8 @@ public class QuestionRegister {
             questionDto.setStatus(question.getStatus());
             questionDto.setFileList(
                 QuestionFileRegister.Response.toDto(question.getQuestionFileList()));
+            questionDto.setLinkList(
+                QuestionLinkRegister.Response.toDto(question.getQuestionLinkList()));
             return questionDto;
         }
     }

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
@@ -2,7 +2,7 @@ package com.checkping.dto.question;
 
 import com.checkping.common.utils.FileRequest;
 import com.checkping.domain.question.Question;
-import com.checkping.dto.question.link.QuestionLinkRequest.RegisterDto;
+import com.checkping.dto.question.link.QuestionLinkRegister;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AccessLevel;
@@ -28,7 +28,7 @@ public class QuestionRegister {
         @Schema(description = "게시글 본문", example = "게시글 본문 입니다.")
         private String content;
         @Schema(description = "게시글 첨부 링크 목록")
-        private List<RegisterDto> linkList;
+        private List<QuestionLinkRegister.Request> linkList;
         @Schema(description = "게시글 첨부 파일 목록")
         private List<FileRequest> fileInfoList;
 
@@ -39,8 +39,10 @@ public class QuestionRegister {
          * @return Question Entity
          */
         public static Question toEntity(QuestionRegister.Request registerDto) {
-            return Question.builder().title(registerDto.getTitle())
-                .content(registerDto.getContent()).build();
+            return Question.builder()
+                .title(registerDto.getTitle())
+                .content(registerDto.getContent())
+                .build();
         }
     }
 

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
@@ -2,7 +2,9 @@ package com.checkping.dto.question;
 
 import com.checkping.common.utils.FileRequest;
 import com.checkping.domain.question.Question;
+import com.checkping.domain.question.Question.Category;
 import com.checkping.dto.question.link.QuestionLinkRegister;
+import com.checkping.exception.question.QuestionCategoryException;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AccessLevel;
@@ -22,6 +24,8 @@ public class QuestionRegister {
         content : 게시글 본문 내용
         linkList : 첨부 링크 리스트 (List<QuestionLinkRequest.RegisterDto>)
         fileInfoList : 첨부 파일 정보 리스트 (List<FileRequest>)
+        category : 게시글 카테고리 (enum, String)
+        progressStepId : 진행 단계 ID
          */
         @Schema(description = "게시글 제목", example = "게시글 제목 입니다.")
         private String title;
@@ -31,6 +35,10 @@ public class QuestionRegister {
         private List<QuestionLinkRegister.Request> linkList;
         @Schema(description = "게시글 첨부 파일 목록")
         private List<FileRequest> fileInfoList;
+        @Schema(description = "게시글 카테고리", example = "QUESTION")
+        private String category;
+        @Schema(description = "진행 단계 ID", example = "1")
+        private Long progressStepId;
 
         /**
          * 업무 관리 게시글 등록 요청 정보로 업무 관리 게시글 엔티티를 만드는 메서드
@@ -38,13 +46,29 @@ public class QuestionRegister {
          * @param registerDto 엄무 관리 게시글 등록 요청 정보
          * @return Question Entity
          */
-        public static Question toEntity(QuestionRegister.Request registerDto) {
-            return Question.builder()
-                .title(registerDto.getTitle())
-                .content(registerDto.getContent())
-                .build();
+        public static Question toEntity(Long projectId,
+            QuestionRegister.Request registerDto) {
+            return Question.generate(projectId, registerDto.getProgressStepId(),
+                registerDto.getTitle(), registerDto.getContent(),
+                convertCategory(registerDto.getCategory()));
         }
     }
 
+    /**
+     * Enum : Category 변환 함수
+     *
+     * @param value Category 로 변환할 문자열
+     * @return Question.Category
+     */
+    public static Category convertCategory(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
 
+        try {
+            return Category.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new QuestionCategoryException(value);
+        }
+    }
 }

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
@@ -1,15 +1,22 @@
 package com.checkping.dto.question;
 
 import com.checkping.common.utils.FileRequest;
+import com.checkping.common.utils.FileResponse;
 import com.checkping.domain.question.Question;
 import com.checkping.domain.question.Question.Category;
+import com.checkping.domain.question.Question.Status;
+import com.checkping.dto.question.comment.QuestionCommentResponse.QuestionCommentDto;
 import com.checkping.dto.question.link.QuestionLinkRegister;
+import com.checkping.dto.question.link.QuestionLinkResponse.QuestionLinkDto;
 import com.checkping.exception.question.QuestionCategoryException;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -51,6 +58,62 @@ public class QuestionRegister {
             return Question.generate(projectId, registerDto.getProgressStepId(),
                 registerDto.getTitle(), registerDto.getContent(),
                 convertCategory(registerDto.getCategory()));
+        }
+    }
+
+    @Getter
+    @Setter(value = AccessLevel.PRIVATE)
+    public static class Response {
+
+        /*
+        id : 게시글 고유 ID
+        number : 게시글 번호
+        title : 게시글 제목
+        content : 게시글 본문 내용
+        regAt : 게시글 작성 일시
+        editAt : 게시글 마지막 수정 일시
+        category : 게시글 카테고리 (enum, String)
+        status : 게시글 상태 (enum, String)
+        commentList : 게시글 댓글 리스트
+        linkList : 게시글 첨부 링크 리스트
+        fileList : 게시글 첨부 파일 리스트
+         */
+        @Schema(description = "게시글 번호")
+        private Long id;
+        @Schema(description = "게시글 번호")
+        private Integer number;
+        @Schema(description = "게시글 제목", example = "게시글 제목 입니다.")
+        private String title;
+        @Schema(description = "게시글 본문", example = "게시글 본문 입니다.")
+        private String content;
+        @Schema(description = "등록 일시")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime regAt;
+        @Schema(description = "수정 일시")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime editAt;
+        @Schema(description = "게시글 유형")
+        private Category category;
+        @Schema(description = "게시글 상태")
+        private Status status;
+        @Schema(description = "게시글 댓글 목록")
+        private List<QuestionCommentDto> commentList;
+        @Schema(description = "게시글 첨부 링크 목록")
+        private List<QuestionLinkDto> linkList;
+        @Schema(description = "게시글 첨부 파일 목록")
+        private List<FileResponse> fileList;
+
+        public static Response toDto(Question question) {
+            Response questionDto = new Response();
+            questionDto.setId(question.getId());
+            questionDto.setNumber(question.getNumber());
+            questionDto.setTitle(question.getTitle());
+            questionDto.setContent(question.getContent());
+            questionDto.setRegAt(question.getRegAt());
+            questionDto.setEditAt(question.getEditAt());
+            questionDto.setCategory(question.getCategory());
+            questionDto.setStatus(question.getStatus());
+            return questionDto;
         }
     }
 

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
@@ -1,23 +1,27 @@
 package com.checkping.dto.question;
 
+import com.checkping.common.utils.FileRequest;
 import com.checkping.domain.question.Question;
 import com.checkping.dto.question.link.QuestionLinkRequest.RegisterDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class QuestionRegister {
 
+    @Getter
+    @ToString
     public static class Request {
 
         /*
         title : 게시글 제목
         content : 게시글 본문 내용
-        category : 게시글 카테고리 (enum, String
-        status : 게시글 상태 (enum, String)
         linkList : 첨부 링크 리스트 (List<QuestionLinkRequest.RegisterDto>)
+        fileInfoList : 첨부 파일 정보 리스트 (List<FileRequest>)
          */
         @Schema(description = "게시글 제목", example = "게시글 제목 입니다.")
         private String title;
@@ -25,17 +29,20 @@ public class QuestionRegister {
         private String content;
         @Schema(description = "게시글 첨부 링크 목록")
         private List<RegisterDto> linkList;
+        @Schema(description = "게시글 첨부 파일 목록")
+        private List<FileRequest> fileInfoList;
+
+        /**
+         * 업무 관리 게시글 등록 요청 정보로 업무 관리 게시글 엔티티를 만드는 메서드
+         *
+         * @param registerDto 엄무 관리 게시글 등록 요청 정보
+         * @return Question Entity
+         */
+        public static Question toEntity(QuestionRegister.Request registerDto) {
+            return Question.builder().title(registerDto.getTitle())
+                .content(registerDto.getContent()).build();
+        }
     }
 
-    /**
-     * 업무 관리 게시글 등록 요청 정보로 업무 관리 게시글 엔티티를 만드는 메서드
-     *
-     * @param registerDto 엄무 관리 게시글 등록 요청 정보
-     * @return Question Entity
-     */
-    public static Question toEntity(QuestionRequest.RegisterDto registerDto) {
-        return Question.builder().title(registerDto.getTitle())
-            .content(registerDto.getContent()).build();
-    }
 
 }

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
@@ -8,7 +8,10 @@ import com.checkping.dto.question.comment.QuestionCommentResponse.QuestionCommen
 import com.checkping.dto.question.file.QuestionFileRegister;
 import com.checkping.dto.question.link.QuestionLinkRegister;
 import com.checkping.exception.question.QuestionCategoryException;
+import com.checkping.exception.question.QuestionContentParsingException;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,6 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.QueryException;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class QuestionRegister {
@@ -36,7 +40,7 @@ public class QuestionRegister {
         @Schema(description = "게시글 제목", example = "게시글 제목 입니다.")
         private String title;
         @Schema(description = "게시글 본문", example = "게시글 본문 입니다.")
-        private String content;
+        private List<QuestionContent> content;
         @Schema(description = "게시글 첨부 링크 목록")
         private List<QuestionLinkRegister.Request> linkList;
         @Schema(description = "게시글 첨부 파일 목록")
@@ -53,8 +57,22 @@ public class QuestionRegister {
         public static Question toEntity(Long projectId,
             QuestionRegister.Request registerDto) {
             return Question.generate(projectId, registerDto.getProgressStepId(),
-                registerDto.getTitle(), registerDto.getContent(),
+                registerDto.getTitle(), registerDto.toContentString(),
                 Category.QUESTION);
+        }
+
+        /**
+         * JSON LIST -> String
+         *
+         * @return content String
+         */
+        private String toContentString() {
+            ObjectMapper objectMapper = new ObjectMapper();
+            try {
+                return objectMapper.writeValueAsString(content);
+            } catch (Exception e) {
+                throw new QuestionContentParsingException();
+            }
         }
     }
 
@@ -82,7 +100,7 @@ public class QuestionRegister {
         @Schema(description = "게시글 제목", example = "게시글 제목 입니다.")
         private String title;
         @Schema(description = "게시글 본문", example = "게시글 본문 입니다.")
-        private String content;
+        private List<QuestionContent> content;
         @Schema(description = "등록 일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime regAt;
@@ -105,7 +123,7 @@ public class QuestionRegister {
             questionDto.setId(question.getId());
             questionDto.setNumber(question.getNumber());
             questionDto.setTitle(question.getTitle());
-            questionDto.setContent(question.getContent());
+            questionDto.setContent(Response.toContentList(question.getContent()));
             questionDto.setRegAt(question.getRegAt());
             questionDto.setEditAt(question.getEditAt());
             questionDto.setCategory(question.getCategory());
@@ -115,6 +133,22 @@ public class QuestionRegister {
             questionDto.setLinkList(
                 QuestionLinkRegister.Response.toDto(question.getQuestionLinkList()));
             return questionDto;
+        }
+
+
+        /**
+         * String -> JSON LIST
+         *
+         * @param content content String
+         * @return content List
+         */
+        private static List<QuestionContent> toContentList(String content) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            try {
+                return objectMapper.readValue(content, new TypeReference<List<QuestionContent>>() {});
+            } catch (Exception e) {
+                throw new QuestionContentParsingException();
+            }
         }
     }
 

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
@@ -1,0 +1,41 @@
+package com.checkping.dto.question;
+
+import com.checkping.domain.question.Question;
+import com.checkping.dto.question.link.QuestionLinkRequest.RegisterDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class QuestionRegister {
+
+    public static class Request {
+
+        /*
+        title : 게시글 제목
+        content : 게시글 본문 내용
+        category : 게시글 카테고리 (enum, String
+        status : 게시글 상태 (enum, String)
+        linkList : 첨부 링크 리스트 (List<QuestionLinkRequest.RegisterDto>)
+         */
+        @Schema(description = "게시글 제목", example = "게시글 제목 입니다.")
+        private String title;
+        @Schema(description = "게시글 본문", example = "게시글 본문 입니다.")
+        private String content;
+        @Schema(description = "게시글 첨부 링크 목록")
+        private List<RegisterDto> linkList;
+    }
+
+    /**
+     * 업무 관리 게시글 등록 요청 정보로 업무 관리 게시글 엔티티를 만드는 메서드
+     *
+     * @param registerDto 엄무 관리 게시글 등록 요청 정보
+     * @return Question Entity
+     */
+    public static Question toEntity(QuestionRequest.RegisterDto registerDto) {
+        return Question.builder().title(registerDto.getTitle())
+            .content(registerDto.getContent()).build();
+    }
+
+}

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
@@ -41,8 +41,6 @@ public class QuestionRegister {
         private List<QuestionLinkRegister.Request> linkList;
         @Schema(description = "게시글 첨부 파일 목록")
         private List<FileRequest> fileInfoList;
-        @Schema(description = "게시글 카테고리", example = "QUESTION")
-        private String category;
         @Schema(description = "진행 단계 ID", example = "1")
         private Long progressStepId;
 
@@ -56,7 +54,7 @@ public class QuestionRegister {
             QuestionRegister.Request registerDto) {
             return Question.generate(projectId, registerDto.getProgressStepId(),
                 registerDto.getTitle(), registerDto.getContent(),
-                convertCategory(registerDto.getCategory()));
+                Category.QUESTION);
         }
     }
 

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
@@ -7,7 +7,6 @@ import com.checkping.domain.question.Question.Status;
 import com.checkping.dto.question.comment.QuestionCommentResponse.QuestionCommentDto;
 import com.checkping.dto.question.file.QuestionFileRegister;
 import com.checkping.dto.question.link.QuestionLinkRegister;
-import com.checkping.dto.question.link.QuestionLinkResponse.QuestionLinkDto;
 import com.checkping.exception.question.QuestionCategoryException;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionRegister.java
@@ -1,11 +1,11 @@
 package com.checkping.dto.question;
 
 import com.checkping.common.utils.FileRequest;
-import com.checkping.common.utils.FileResponse;
 import com.checkping.domain.question.Question;
 import com.checkping.domain.question.Question.Category;
 import com.checkping.domain.question.Question.Status;
 import com.checkping.dto.question.comment.QuestionCommentResponse.QuestionCommentDto;
+import com.checkping.dto.question.file.QuestionFileRegister;
 import com.checkping.dto.question.link.QuestionLinkRegister;
 import com.checkping.dto.question.link.QuestionLinkResponse.QuestionLinkDto;
 import com.checkping.exception.question.QuestionCategoryException;
@@ -101,7 +101,7 @@ public class QuestionRegister {
         @Schema(description = "게시글 첨부 링크 목록")
         private List<QuestionLinkDto> linkList;
         @Schema(description = "게시글 첨부 파일 목록")
-        private List<FileResponse> fileList;
+        private List<QuestionFileRegister.Response> fileList;
 
         public static Response toDto(Question question) {
             Response questionDto = new Response();
@@ -113,6 +113,8 @@ public class QuestionRegister {
             questionDto.setEditAt(question.getEditAt());
             questionDto.setCategory(question.getCategory());
             questionDto.setStatus(question.getStatus());
+            questionDto.setFileList(
+                QuestionFileRegister.Response.toDto(question.getQuestionFileList()));
             return questionDto;
         }
     }

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionResponse.java
@@ -66,7 +66,6 @@ public class QuestionResponse {
             boardDto.setContent(question.getContent());
             boardDto.setRegAt(question.getRegAt());
             boardDto.setEditAt(question.getEditAt());
-            boardDto.setApproverAt(question.getApproverAt());
             boardDto.setCategory(question.getCategory());
             boardDto.setStatus(question.getStatus());
             boardDto.setDeletedYn(question.getDeletedYn());
@@ -128,7 +127,6 @@ public class QuestionResponse {
             boardDto.setContent(question.getContent());
             boardDto.setRegAt(question.getRegAt());
             boardDto.setEditAt(question.getEditAt());
-            boardDto.setApproverAt(question.getApproverAt());
             boardDto.setCategory(question.getCategory());
             boardDto.setStatus(question.getStatus());
             boardDto.setDeletedYn(question.getDeletedYn());

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionResponse.java
@@ -128,8 +128,8 @@ public class QuestionResponse {
             boardDto.setRegAt(question.getRegAt());
             boardDto.setEditAt(question.getEditAt());
             boardDto.setCategory(question.getCategory());
-            boardDto.setStatus(question.getStatus());
             boardDto.setDeletedYn(question.getDeletedYn());
+            boardDto.setStatus(question.getStatus());
 
             // Entity -> Dto (QuestionComment)
             List<QuestionCommentDto> comments =

--- a/module-service/src/main/java/com/checkping/dto/question/file/QuestionFileRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/file/QuestionFileRegister.java
@@ -1,0 +1,64 @@
+package com.checkping.dto.question.file;
+
+import com.checkping.domain.question.QuestionFile;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class QuestionFileRegister {
+
+    @Getter
+    public static class Response {
+
+        /*
+        id : id
+        questionId : 게시글 번호
+        originalName : 원본 파일명
+        saveName : 저장 파일명
+        url : 저장 URL
+        size : 파일 Size
+         */
+        private Long id;
+        private Long questionId;
+        private String originalName;
+        private String saveName;
+        private String url;
+        private long size;
+
+        /**
+         * QuestionFile Entity -> Response Dto
+         *
+         * @param questionFile QuestionFile Entity
+         * @return Response Dto
+         */
+        public static Response toDto(QuestionFile questionFile) {
+            Response response = new Response();
+            response.id = questionFile.getId();
+            response.questionId = questionFile.getQuestion().getId();
+            response.originalName = questionFile.getOriginalName();
+            response.saveName = questionFile.getSaveName();
+            response.url = questionFile.getUrl();
+            response.size = questionFile.getSize();
+            return response;
+        }
+
+        /**
+         * QuestionFile Entity List -> Response Dto List
+         *
+         * @param questionFiles QuestionFile Entity List
+         * @return Response Dto List
+         */
+        public static List<Response> toDto(List<QuestionFile> questionFiles) {
+            // Check null or empty
+            if (questionFiles == null || questionFiles.isEmpty()) {
+                return List.of();
+            }
+
+            return questionFiles.stream()
+                .map(QuestionFileRegister.Response::toDto)
+                .toList();
+        }
+    }
+}

--- a/module-service/src/main/java/com/checkping/dto/question/file/QuestionFileRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/file/QuestionFileRegister.java
@@ -1,5 +1,7 @@
 package com.checkping.dto.question.file;
 
+import com.checkping.common.utils.FileRequest;
+import com.checkping.domain.question.Question;
 import com.checkping.domain.question.QuestionFile;
 import java.util.List;
 import lombok.AccessLevel;
@@ -8,6 +10,53 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class QuestionFileRegister {
+
+    @Getter
+    public static class Request {
+
+        /*
+        originalName : 원본 파일명
+        saveName : 저장 파일명
+        url : 저장 URL
+        size : 파일 Size
+         */
+        private String originalName;
+        private String saveName;
+        private String url;
+        private long size;
+
+        /**
+         * FileRequest Dto -> QuestionFile Entity
+         *
+         * @param question Question Entity
+         * @param request  FileRequest Dto (첨부 파일)
+         * @return QuestionFile Entity
+         */
+        public static QuestionFile toEntity(Question question, FileRequest request) {
+
+            return QuestionFile.generate(question, request.originalName(), request.saveName(),
+                request.url(), request.size());
+        }
+
+
+        /**
+         * FileRequest Dto List -> QuestionFile Entity List
+         *
+         * @param question Question Entity
+         * @param requests FileRequest Dto List (첨부 파일 리스트)
+         * @return List<QuestionFile> Entity List
+         */
+        public static List<QuestionFile> toEntity(Question question,
+            List<FileRequest> requests) {
+
+            // Check null or empty
+            if (requests == null || requests.isEmpty()) {
+                return List.of();
+            }
+
+            return requests.stream().map(request -> toEntity(question, request)).toList();
+        }
+    }
 
     @Getter
     public static class Response {
@@ -56,9 +105,7 @@ public class QuestionFileRegister {
                 return List.of();
             }
 
-            return questionFiles.stream()
-                .map(QuestionFileRegister.Response::toDto)
-                .toList();
+            return questionFiles.stream().map(QuestionFileRegister.Response::toDto).toList();
         }
     }
 }

--- a/module-service/src/main/java/com/checkping/dto/question/link/QuestionLinkRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/link/QuestionLinkRegister.java
@@ -55,6 +55,7 @@ public class QuestionLinkRegister {
         }
     }
 
+    @Getter
     public static class Response {
         /*
         id : 게시글 링크 아이디

--- a/module-service/src/main/java/com/checkping/dto/question/link/QuestionLinkRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/link/QuestionLinkRegister.java
@@ -25,34 +25,81 @@ public class QuestionLinkRegister {
         @Schema(description = "게시글 링크 url")
         private String url;
 
+        /**
+         * QuestionLink 등록 요청 Dto -> QuestionLink Entity
+         *
+         * @param question Question Entity
+         * @param request  QuestionLinkRegister.Request Dto
+         * @return QuestionLink Entity
+         */
+        public static QuestionLink toEntity(Question question, QuestionLinkRegister.Request request) {
+            return QuestionLink.builder()
+                .name(request.getName())
+                .url(request.getUrl())
+                .question(question)
+                .build();
+        }
+
+        /**
+         * QuestionLink 등록 요청 Dto 리스트 -> QuestionLink Entity 리스트
+         *
+         * @param question Question Entity
+         * @param requests QuestionLinkRegister.Request List
+         * @return List<QuestionLink> Entity List
+         */
+        public static List<QuestionLink> toEntity(Question question,
+            List<QuestionLinkRegister.Request> requests) {
+            return requests.stream()
+                .map(request -> toEntity(question, request))
+                .toList();
+        }
     }
 
-    /**
-     * QuestionLink 등록 요청 Dto -> QuestionLink Entity
-     *
-     * @param question Question Entity
-     * @param request  QuestionLinkRegister.Request Dto
-     * @return QuestionLink Entity
-     */
-    public static QuestionLink toEntity(Question question, QuestionLinkRegister.Request request) {
-        return QuestionLink.builder()
-            .name(request.getName())
-            .url(request.getUrl())
-            .question(question)
-            .build();
+    public static class Response {
+        /*
+        id : 게시글 링크 아이디
+        projectId : 프로젝트 아이디
+        name : 게시글 링크 이름
+        url : 게시글 링크 url
+         */
+
+        private Long id;
+        private Long projectId;
+        private String name;
+        private String url;
+
+        /**
+         * QuestionLink Entity -> QuestionLinkRegister.Response Dto
+         *
+         * @param link QuestionLink Entity
+         * @return QuestionLinkRegister.Response Dto
+         */
+        public static QuestionLinkRegister.Response toDto(QuestionLink link) {
+            QuestionLinkRegister.Response dto = new QuestionLinkRegister.Response();
+            dto.id = link.getId();
+            // TODO : projectId 실제로 찾아서 가져오기 (getProject() 로 변경 예정이기 때문)
+            dto.projectId = link.getQuestion().getProjectId();
+            dto.name = link.getName();
+            dto.url = link.getUrl();
+            return dto;
+        }
+
+        /**
+         * QuestionLink Entity 리스트 -> QuestionLinkRegister.Response Dto 리스트
+         *
+         * @param links QuestionLink Entity List
+         * @return List<QuestionLinkRegister.Response> Dto List
+         */
+        public static List<QuestionLinkRegister.Response> toDto(List<QuestionLink> links) {
+            // Check null or empty
+            if (links == null || links.isEmpty()) {
+                return List.of();
+            }
+
+            return links.stream()
+                .map(QuestionLinkRegister.Response::toDto)
+                .toList();
+        }
     }
 
-    /**
-     * QuestionLink 등록 요청 Dto 리스트 -> QuestionLink Entity 리스트
-     *
-     * @param question Question Entity
-     * @param requests QuestionLinkRegister.Request List
-     * @return List<QuestionLink> Entity List
-     */
-    public static List<QuestionLink> toEntity(Question question,
-        List<QuestionLinkRegister.Request> requests) {
-        return requests.stream()
-            .map(request -> toEntity(question, request))
-            .toList();
-    }
 }

--- a/module-service/src/main/java/com/checkping/dto/question/link/QuestionLinkRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/question/link/QuestionLinkRegister.java
@@ -1,0 +1,58 @@
+package com.checkping.dto.question.link;
+
+import com.checkping.domain.question.Question;
+import com.checkping.domain.question.QuestionLink;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class QuestionLinkRegister {
+
+    @Getter
+    @ToString
+    public static class Request {
+        /*
+        name : 게시글 링크 이름
+        url : 게시글 링크 url
+         */
+
+        @Schema(description = "게시글 링크 이름")
+        private String name;
+        @Schema(description = "게시글 링크 url")
+        private String url;
+
+    }
+
+    /**
+     * QuestionLink 등록 요청 Dto -> QuestionLink Entity
+     *
+     * @param question Question Entity
+     * @param request  QuestionLinkRegister.Request Dto
+     * @return QuestionLink Entity
+     */
+    public static QuestionLink toEntity(Question question, QuestionLinkRegister.Request request) {
+        return QuestionLink.builder()
+            .name(request.getName())
+            .url(request.getUrl())
+            .question(question)
+            .build();
+    }
+
+    /**
+     * QuestionLink 등록 요청 Dto 리스트 -> QuestionLink Entity 리스트
+     *
+     * @param question Question Entity
+     * @param requests QuestionLinkRegister.Request List
+     * @return List<QuestionLink> Entity List
+     */
+    public static List<QuestionLink> toEntity(Question question,
+        List<QuestionLinkRegister.Request> requests) {
+        return requests.stream()
+            .map(request -> toEntity(question, request))
+            .toList();
+    }
+}

--- a/module-service/src/main/java/com/checkping/exception/question/QuestionContentParsingException.java
+++ b/module-service/src/main/java/com/checkping/exception/question/QuestionContentParsingException.java
@@ -1,0 +1,10 @@
+package com.checkping.exception.question;
+
+import com.checkping.common.enums.ErrorCode;
+
+public class QuestionContentParsingException extends QuestionException {
+
+    public QuestionContentParsingException() {
+        super("게시글 파싱에 실패하였습니다.", ErrorCode.INVALID_INPUT_VALUE);
+    }
+}

--- a/module-service/src/main/java/com/checkping/service/question/QuestionService.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionService.java
@@ -8,7 +8,7 @@ import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
 import java.util.List;
 
 public interface QuestionService {
-    QuestionItemDto register(Request request);
+    QuestionItemDto register(Long projectId, Request request);
     List<QuestionListDto> getQuestionList(QuestionRequest.SearchCondition searchCondition);
     QuestionItemDto getQuestionById(Long taskBoardId);
     QuestionListDto deleteSoft (Long taskBoardId);

--- a/module-service/src/main/java/com/checkping/service/question/QuestionService.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionService.java
@@ -6,10 +6,9 @@ import com.checkping.dto.question.QuestionRequest.UpdateDto;
 import com.checkping.dto.question.QuestionResponse.QuestionListDto;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
 import java.util.List;
-import org.springframework.web.multipart.MultipartFile;
 
 public interface QuestionService {
-    QuestionItemDto register(Request request, List<MultipartFile> fileList);
+    QuestionItemDto register(Request request);
     List<QuestionListDto> getQuestionList(QuestionRequest.SearchCondition searchCondition);
     QuestionItemDto getQuestionById(Long taskBoardId);
     QuestionListDto deleteSoft (Long taskBoardId);

--- a/module-service/src/main/java/com/checkping/service/question/QuestionService.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionService.java
@@ -1,7 +1,7 @@
 package com.checkping.service.question;
 
+import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest;
-import com.checkping.dto.question.QuestionRequest.RegisterDto;
 import com.checkping.dto.question.QuestionRequest.UpdateDto;
 import com.checkping.dto.question.QuestionResponse.QuestionListDto;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
@@ -9,7 +9,7 @@ import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface QuestionService {
-    QuestionItemDto register(RegisterDto request, List<MultipartFile> fileList);
+    QuestionItemDto register(Request request, List<MultipartFile> fileList);
     List<QuestionListDto> getQuestionList(QuestionRequest.SearchCondition searchCondition);
     QuestionItemDto getQuestionById(Long taskBoardId);
     QuestionListDto deleteSoft (Long taskBoardId);

--- a/module-service/src/main/java/com/checkping/service/question/QuestionService.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionService.java
@@ -1,14 +1,15 @@
 package com.checkping.service.question;
 
+import com.checkping.dto.question.QuestionRegister;
 import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest;
 import com.checkping.dto.question.QuestionRequest.UpdateDto;
-import com.checkping.dto.question.QuestionResponse.QuestionListDto;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
+import com.checkping.dto.question.QuestionResponse.QuestionListDto;
 import java.util.List;
 
 public interface QuestionService {
-    QuestionItemDto register(Long projectId, Request request);
+    QuestionRegister.Response register(Long projectId, Request request);
     List<QuestionListDto> getQuestionList(QuestionRequest.SearchCondition searchCondition);
     QuestionItemDto getQuestionById(Long taskBoardId);
     QuestionListDto deleteSoft (Long taskBoardId);

--- a/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
@@ -49,10 +49,11 @@ public class QuestionServiceImpl implements QuestionService {
         Project project = projectReader.getById(projectId);
 
         // Question Dto -> Question Entity
-        Question initQuestion = QuestionRegister.Request.toEntity(project, request);
+        Question initQuestion = QuestionRegister.Request.toEntity(request);
         initQuestion.activate();
         initQuestion.updateCategory(Question.Category.QUESTION);
         initQuestion.updateStatus(Question.Status.WAIT);
+        initQuestion.containedProject(project);
 
         // save Question entity
         Question question = questionStore.store(initQuestion);

--- a/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
@@ -45,15 +45,8 @@ public class QuestionServiceImpl implements QuestionService {
     @Override
     public QuestionItemDto register(Long projectId, QuestionRegister.Request request) {
 
-        // Project ID -> Project Entity
-        Project project = projectReader.getById(projectId);
-
         // Question Dto -> Question Entity
-        Question initQuestion = QuestionRegister.Request.toEntity(request);
-        initQuestion.activate();
-        initQuestion.updateCategory(Question.Category.QUESTION);
-        initQuestion.updateStatus(Question.Status.WAIT);
-        initQuestion.containedProject(project);
+        Question initQuestion = QuestionRegister.Request.toEntity(projectId, request);
 
         // save Question entity
         Question question = questionStore.store(initQuestion);

--- a/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
@@ -10,6 +10,7 @@ import com.checkping.dto.question.QuestionRequest.SearchCondition;
 import com.checkping.dto.question.QuestionRequest.UpdateDto;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
 import com.checkping.dto.question.QuestionResponse.QuestionListDto;
+import com.checkping.dto.question.file.QuestionFileRegister;
 import com.checkping.dto.question.link.QuestionLinkRegister;
 import com.checkping.exception.question.QuestionNotFoundEntityException;
 import com.checkping.infra.repository.project.ProjectReader;
@@ -51,18 +52,16 @@ public class QuestionServiceImpl implements QuestionService {
         // save Question entity
         Question question = questionStore.store(initQuestion);
 
+        // QuestionFileRequest.RegisterDto -> QuestionFile Entity
+        List<QuestionFile> files = QuestionFileRegister.Request.toEntity(question, request.getFileInfoList());
         // Save & Add QuestionFile List
-        List<QuestionFile> questionFileList = questionFileStore.storeFileList(question,
-            request.getFileInfoList());
-        question.addFile(questionFileList);
+        questionFileStore.store(files);
+        question.addFile(files);
 
         // QuestionLinkRequest.RegisterDto -> QuestionLink Entity
-        List<QuestionLink> links = QuestionLinkRegister.toEntity(question, request.getLinkList());
-
-        // save QuestionLink
+        List<QuestionLink> links = QuestionLinkRegister.Request.toEntity(question, request.getLinkList());
+        // Save & Add QuestionLink
         questionLinkStore.store(links);
-
-        // ADD QuestionLink (in Question)
         question.addLink(links);
 
         // Entity -> Dto

--- a/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
@@ -1,9 +1,11 @@
 package com.checkping.service.question;
 
+import com.checkping.common.utils.FileResponse;
 import com.checkping.domain.question.Question;
 import com.checkping.domain.question.QuestionComment;
 import com.checkping.domain.question.QuestionFile;
 import com.checkping.domain.question.QuestionLink;
+import com.checkping.dto.question.QuestionRegister;
 import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest;
 import com.checkping.dto.question.QuestionRequest.SearchCondition;
@@ -21,7 +23,6 @@ import com.checkping.infra.repository.question.link.QuestionLinkStore;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -37,15 +38,14 @@ public class QuestionServiceImpl implements QuestionService {
     /**
      * 업무 관리 게시글 등록하기
      *
-     * @param request  업무 관리 게시글에 필요한 request
-     * @param fileList 첨부 파일 리스트
+     * @param request 업무 관리 게시글에 필요한 request
      * @return 생성한 Question 의 Dto
      */
     @Override
-    public QuestionItemDto register(Request request, List<MultipartFile> fileList) {
+    public QuestionItemDto register(Request request) {
 
         // dto -> entity
-        Question initQuestion = QuestionRequest.RegisterDto.toEntity(request);
+        Question initQuestion = QuestionRegister.Request.toEntity(request);
         initQuestion.activate();
         initQuestion.updateCategory(Question.Category.QUESTION);
         initQuestion.updateStatus(Question.Status.WAIT);
@@ -53,11 +53,8 @@ public class QuestionServiceImpl implements QuestionService {
         // save Question entity
         Question question = questionStore.store(initQuestion);
 
-        // Save File in S3
-        List<QuestionFile> questionFileList = questionFileStore.saveFileList(question,
-            fileList);
-
-        // Add QuestionFile List
+        // Save & Add QuestionFile List
+        List<QuestionFile> questionFileList = questionFileStore.storeFileList(question, request.getFileInfoList());
         question.addFile(questionFileList);
 
         // get register info

--- a/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
@@ -4,8 +4,8 @@ import com.checkping.domain.question.Question;
 import com.checkping.domain.question.QuestionComment;
 import com.checkping.domain.question.QuestionFile;
 import com.checkping.domain.question.QuestionLink;
+import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest;
-import com.checkping.dto.question.QuestionRequest.RegisterDto;
 import com.checkping.dto.question.QuestionRequest.SearchCondition;
 import com.checkping.dto.question.QuestionRequest.UpdateDto;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
@@ -42,7 +42,7 @@ public class QuestionServiceImpl implements QuestionService {
      * @return 생성한 Question 의 Dto
      */
     @Override
-    public QuestionItemDto register(RegisterDto request, List<MultipartFile> fileList) {
+    public QuestionItemDto register(Request request, List<MultipartFile> fileList) {
 
         // dto -> entity
         Question initQuestion = QuestionRequest.RegisterDto.toEntity(request);

--- a/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
@@ -1,19 +1,18 @@
 package com.checkping.service.question;
 
-import com.checkping.common.utils.FileResponse;
+import com.checkping.domain.project.Project;
 import com.checkping.domain.question.Question;
 import com.checkping.domain.question.QuestionComment;
 import com.checkping.domain.question.QuestionFile;
 import com.checkping.domain.question.QuestionLink;
 import com.checkping.dto.question.QuestionRegister;
-import com.checkping.dto.question.QuestionRegister.Request;
-import com.checkping.dto.question.QuestionRequest;
 import com.checkping.dto.question.QuestionRequest.SearchCondition;
 import com.checkping.dto.question.QuestionRequest.UpdateDto;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
 import com.checkping.dto.question.QuestionResponse.QuestionListDto;
 import com.checkping.dto.question.link.QuestionLinkRequest;
 import com.checkping.exception.question.QuestionNotFoundEntityException;
+import com.checkping.infra.repository.project.ProjectReader;
 import com.checkping.infra.repository.question.QuestionReader;
 import com.checkping.infra.repository.question.QuestionStore;
 import com.checkping.infra.repository.question.comment.QuestionCommentReader;
@@ -34,18 +33,23 @@ public class QuestionServiceImpl implements QuestionService {
     private final QuestionCommentStore questionCommentStore;
     private final QuestionLinkStore questionLinkStore;
     private final QuestionFileStore questionFileStore;
+    private final ProjectReader projectReader;
 
     /**
      * 업무 관리 게시글 등록하기
      *
-     * @param request 업무 관리 게시글에 필요한 request
+     * @param projectId 프로젝트 ID
+     * @param request   업무 관리 게시글에 필요한 request
      * @return 생성한 Question 의 Dto
      */
     @Override
-    public QuestionItemDto register(Request request) {
+    public QuestionItemDto register(Long projectId, QuestionRegister.Request request) {
 
-        // dto -> entity
-        Question initQuestion = QuestionRegister.Request.toEntity(request);
+        // Project ID -> Project Entity
+        Project project = projectReader.getById(projectId);
+
+        // Question Dto -> Question Entity
+        Question initQuestion = QuestionRegister.Request.toEntity(project, request);
         initQuestion.activate();
         initQuestion.updateCategory(Question.Category.QUESTION);
         initQuestion.updateStatus(Question.Status.WAIT);
@@ -54,7 +58,8 @@ public class QuestionServiceImpl implements QuestionService {
         Question question = questionStore.store(initQuestion);
 
         // Save & Add QuestionFile List
-        List<QuestionFile> questionFileList = questionFileStore.storeFileList(question, request.getFileInfoList());
+        List<QuestionFile> questionFileList = questionFileStore.storeFileList(question,
+            request.getFileInfoList());
         question.addFile(questionFileList);
 
         // get register info

--- a/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
@@ -1,11 +1,11 @@
 package com.checkping.service.question;
 
-import com.checkping.domain.project.Project;
 import com.checkping.domain.question.Question;
 import com.checkping.domain.question.QuestionComment;
 import com.checkping.domain.question.QuestionFile;
 import com.checkping.domain.question.QuestionLink;
 import com.checkping.dto.question.QuestionRegister;
+import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest.SearchCondition;
 import com.checkping.dto.question.QuestionRequest.UpdateDto;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
@@ -43,7 +43,7 @@ public class QuestionServiceImpl implements QuestionService {
      * @return 생성한 Question 의 Dto
      */
     @Override
-    public QuestionItemDto register(Long projectId, QuestionRegister.Request request) {
+    public QuestionRegister.Response register(Long projectId, Request request) {
 
         // Question Dto -> Question Entity
         Question initQuestion = QuestionRegister.Request.toEntity(projectId, request);
@@ -66,7 +66,7 @@ public class QuestionServiceImpl implements QuestionService {
         question.addLink(links);
 
         // Entity -> Dto
-        return QuestionItemDto.toDto(question);
+        return QuestionRegister.Response.toDto(question);
     }
 
     /**

--- a/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
@@ -10,7 +10,7 @@ import com.checkping.dto.question.QuestionRequest.SearchCondition;
 import com.checkping.dto.question.QuestionRequest.UpdateDto;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
 import com.checkping.dto.question.QuestionResponse.QuestionListDto;
-import com.checkping.dto.question.link.QuestionLinkRequest;
+import com.checkping.dto.question.link.QuestionLinkRegister;
 import com.checkping.exception.question.QuestionNotFoundEntityException;
 import com.checkping.infra.repository.project.ProjectReader;
 import com.checkping.infra.repository.question.QuestionReader;
@@ -63,22 +63,14 @@ public class QuestionServiceImpl implements QuestionService {
             request.getFileInfoList());
         question.addFile(questionFileList);
 
-        // get register info
-        List<QuestionLinkRequest.RegisterDto> linkDtoList = request.getLinkList();
+        // QuestionLinkRequest.RegisterDto -> QuestionLink Entity
+        List<QuestionLink> links = QuestionLinkRegister.toEntity(question, request.getLinkList());
 
-        // loop for add taskBoardLinkRequest
-        for (QuestionLinkRequest.RegisterDto linkDto : linkDtoList) {
+        // save QuestionLink
+        questionLinkStore.store(links);
 
-            // QuestionLink Dto -> Entity
-            QuestionLink initQuestionLink = QuestionLinkRequest.RegisterDto.toEntity(question,
-                linkDto);
-
-            // save QuestionLink
-            QuestionLink questionLink = questionLinkStore.store(initQuestionLink);
-
-            // ADD QuestionLink (in Question)
-            question.addLink(questionLink);
-        }
+        // ADD QuestionLink (in Question)
+        question.addLink(links);
 
         // Entity -> Dto
         return QuestionItemDto.toDto(question);


### PR DESCRIPTION
# 🚀 Pull Request

## 급하게 작업하다보니 한 PR 에 많은 코드가 들어가게 되었습니다. 질문 게시글 수정, 삭제, 조회 만 이렇게 하고 다음부터는 적절하게 끊도록 하겠습니다.

**[질문 게시글 생성 api 수정 및 연동]**


## #️⃣ 연관된 이슈

- #210

## 📋 작업 내용

1. 기존에 사용하던 QuestionRequest Dto 를 QuestionRegister 로 묶어서 사용
2. Question Entity 의 연관관계 맵핑
3. Question.content 를 VARCHAR 에서 TEXT 로 변경
