### PR TITLE
Feature/290 feature 질문 게시글 상세 조회 추가 기능

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/question/QuestionApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/question/QuestionApi.java
@@ -36,7 +36,7 @@ public interface QuestionApi {
         @Parameter(description = "페이지 사이즈") Integer pageSize);
 
     @Operation(summary = "질문 게시글 상세 조회", description = "질문 게시글을 조회하는 기능입니다.")
-    BaseResponse<QuestionItemDto> getQuestion(@Parameter(description = "프로젝트 ID") Long projectId,
+    BaseResponse<QuestionItemDto> get(@Parameter(description = "프로젝트 ID") Long projectId,
         @Parameter(description = "게시글 ID") Long questionId);
 
     @Operation(summary = "질문 게시글 수정", description = "질문 게시글을 수정하는 기능입니다.")

--- a/module-api/src/main/java/com/checkping/api/controller/question/QuestionApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/question/QuestionApi.java
@@ -2,12 +2,14 @@ package com.checkping.api.controller.question;
 
 import com.checkping.common.response.BaseResponse;
 import com.checkping.dto.question.QuestionCounter.Response;
+import com.checkping.dto.question.QuestionGet;
 import com.checkping.dto.question.QuestionRegister;
 import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest.UpdateDto;
 import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
 import com.checkping.dto.question.QuestionResponse.QuestionListDto;
 import com.checkping.dto.question.QuestionSearch;
+import com.checkping.dto.question.comment.QuestionCommentGet;
 import com.checkping.dto.question.comment.QuestionCommentRegister;
 import com.checkping.dto.question.comment.QuestionCommentRequest;
 import com.checkping.dto.question.comment.QuestionCommentResponse.QuestionCommentDto;
@@ -36,7 +38,7 @@ public interface QuestionApi {
         @Parameter(description = "페이지 사이즈") Integer pageSize);
 
     @Operation(summary = "질문 게시글 상세 조회", description = "질문 게시글을 조회하는 기능입니다.")
-    BaseResponse<QuestionItemDto> get(@Parameter(description = "프로젝트 ID") Long projectId,
+    BaseResponse<QuestionGet.Response> get(@Parameter(description = "프로젝트 ID") Long projectId,
         @Parameter(description = "게시글 ID") Long questionId);
 
     @Operation(summary = "질문 게시글 수정", description = "질문 게시글을 수정하는 기능입니다.")

--- a/module-api/src/main/java/com/checkping/api/controller/question/QuestionController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/question/QuestionController.java
@@ -79,9 +79,9 @@ public class QuestionController implements QuestionApi {
     public BaseResponse<QuestionGet.Response> get(@PathVariable Long projectId,
         @PathVariable Long questionId) {
 
-        QuestionGet.Response questionItemDto = questionService.getById(questionId);
+        QuestionGet.Response response = questionService.getById(questionId);
 
-        return BaseResponse.success(questionItemDto);
+        return BaseResponse.success(response);
     }
 
     @PutMapping("/{questionId}")

--- a/module-api/src/main/java/com/checkping/api/controller/question/QuestionController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/question/QuestionController.java
@@ -74,7 +74,7 @@ public class QuestionController implements QuestionApi {
 
     @GetMapping("/{questionId}")
     @Override
-    public BaseResponse<QuestionItemDto> getQuestion(@PathVariable Long projectId,
+    public BaseResponse<QuestionItemDto> get(@PathVariable Long projectId,
         @PathVariable Long questionId) {
 
         QuestionItemDto questionItemDto = questionService.getQuestionById(questionId);

--- a/module-api/src/main/java/com/checkping/api/controller/question/QuestionController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/question/QuestionController.java
@@ -3,6 +3,7 @@ package com.checkping.api.controller.question;
 import com.checkping.common.response.BaseResponse;
 import com.checkping.dto.question.QuestionCounter;
 import com.checkping.dto.question.QuestionCounter.Response;
+import com.checkping.dto.question.QuestionGet;
 import com.checkping.dto.question.QuestionRegister;
 import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest.UpdateDto;
@@ -10,6 +11,7 @@ import com.checkping.dto.question.QuestionResponse.QuestionItemDto;
 import com.checkping.dto.question.QuestionResponse.QuestionListDto;
 import com.checkping.dto.question.QuestionSearch;
 import com.checkping.dto.question.QuestionSearchCondition;
+import com.checkping.dto.question.comment.QuestionCommentGet;
 import com.checkping.dto.question.comment.QuestionCommentRegister;
 import com.checkping.dto.question.comment.QuestionCommentRequest;
 import com.checkping.dto.question.comment.QuestionCommentResponse.QuestionCommentDto;
@@ -74,10 +76,10 @@ public class QuestionController implements QuestionApi {
 
     @GetMapping("/{questionId}")
     @Override
-    public BaseResponse<QuestionItemDto> get(@PathVariable Long projectId,
+    public BaseResponse<QuestionGet.Response> get(@PathVariable Long projectId,
         @PathVariable Long questionId) {
 
-        QuestionItemDto questionItemDto = questionService.getById(questionId);
+        QuestionGet.Response questionItemDto = questionService.getById(questionId);
 
         return BaseResponse.success(questionItemDto);
     }

--- a/module-api/src/main/java/com/checkping/api/controller/question/QuestionController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/question/QuestionController.java
@@ -77,7 +77,7 @@ public class QuestionController implements QuestionApi {
     public BaseResponse<QuestionItemDto> get(@PathVariable Long projectId,
         @PathVariable Long questionId) {
 
-        QuestionItemDto questionItemDto = questionService.getQuestionById(questionId);
+        QuestionItemDto questionItemDto = questionService.getById(questionId);
 
         return BaseResponse.success(questionItemDto);
     }

--- a/module-domain/src/main/java/com/checkping/domain/question/Question.java
+++ b/module-domain/src/main/java/com/checkping/domain/question/Question.java
@@ -1,7 +1,6 @@
 package com.checkping.domain.question;
 
 import com.checkping.domain.BaseEntity;
-import com.checkping.domain.member.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -102,6 +101,7 @@ public class Question extends BaseEntity {
     // TODO : ProgressStep progressStep 로 변경할 것
     private Long progressStepId;
 
+    @Builder.Default
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
     private List<QuestionComment> commentList = new ArrayList<>();
 

--- a/module-domain/src/main/java/com/checkping/domain/question/QuestionComment.java
+++ b/module-domain/src/main/java/com/checkping/domain/question/QuestionComment.java
@@ -39,6 +39,7 @@ public class QuestionComment extends BaseEntity {
     parentId : 부모 댓글 아이디
     deletedYn : 삭제 여부
     question : 업무 관리 게시글 (join)
+    parent : 부모 댓글 (join)
      */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionReader.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionReader.java
@@ -11,6 +11,8 @@ public interface QuestionReader {
 
     Optional<Question> getById(Long questionId);
 
+    Optional<Question> getByIdWithComments(Long questionId);
+
     Long countQuestionsByProject(Long projectId);
 
     Long countQuestionsByProgressStep(Long projectId, Long progressStepId);

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionReader.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionReader.java
@@ -9,7 +9,7 @@ public interface QuestionReader {
 
     Page<Question> searchQuestions(Long projectId, QuestionSearchInfo.SearchCondition searchCondition);
 
-    Optional<Question> getQuestionById(Long id);
+    Optional<Question> getById(Long questionId);
 
     Long countQuestionsByProject(Long projectId);
 

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionReaderImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionReaderImpl.java
@@ -142,6 +142,6 @@ public class QuestionReaderImpl implements QuestionReader {
      */
     @Override
     public boolean checkQuestionContaining(Long projectId, Long questionId) {
-        return questionRepository.existsByIdAndProjectId(questionId, projectId);
+        return questionRepository.existsByProjectIdAndId(projectId, questionId);
     }
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionReaderImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionReaderImpl.java
@@ -100,6 +100,17 @@ public class QuestionReaderImpl implements QuestionReader {
     }
 
     /**
+     * Question 조회 기능 (Comment 포함)
+     *
+     * @param questionId question 아이디
+     * @return Question 조회 결과
+     */
+    @Override
+    public Optional<Question> getByIdWithComments(Long questionId) {
+        return questionRepository.findByIdWithComments(questionId);
+    }
+
+    /**
      * 프로젝트별 Question 개수 조회
      *
      * @param projectId project id

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionReaderImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionReaderImpl.java
@@ -91,12 +91,12 @@ public class QuestionReaderImpl implements QuestionReader {
     /**
      * Question 조회 기능
      *
-     * @param id question 아이디
+     * @param questionId question 아이디
      * @return Question 조회 결과
      */
     @Override
-    public Optional<Question> getQuestionById(Long id) {
-        return questionRepository.findById(id);
+    public Optional<Question> getById(Long questionId) {
+        return questionRepository.findById(questionId);
     }
 
     /**

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionRepository.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,21 +15,33 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     Optional<Question> findById(Long id);
 
+    @Query("SELECT q FROM Question q " +
+        "LEFT JOIN FETCH q.commentList c " +
+        "WHERE q.id = :questionId " +
+        "ORDER BY COALESCE(c.parent.id, c.id) , c.regAt ASC")
+    Optional<Question> findByIdWithComments(@Param("questionId") Long id);
+
     Page<Question> findByProjectId(Long projectId, Pageable pageable);
 
-    Page<Question> findByProjectIdAndProgressStepId(Long projectId, Long progressStepId, Pageable pageable);
+    Page<Question> findByProjectIdAndProgressStepId(Long projectId, Long progressStepId,
+        Pageable pageable);
 
     Page<Question> findByProjectIdAndStatus(Long projectId, Status status, Pageable pageable);
 
-    Page<Question> findByProjectIdAndProgressStepIdAndStatus(Long projectId, Long progressId, Status status, Pageable pageable);
+    Page<Question> findByProjectIdAndProgressStepIdAndStatus(Long projectId, Long progressId,
+        Status status, Pageable pageable);
 
-    Page<Question> findByProjectIdAndTitleContaining(Long projectId, String title, Pageable pageable);
+    Page<Question> findByProjectIdAndTitleContaining(Long projectId, String title,
+        Pageable pageable);
 
-    Page<Question> findByProjectIdAndProgressStepIdAndTitleContaining(Long projectId, Long progressStepId, String title, Pageable pageable);
+    Page<Question> findByProjectIdAndProgressStepIdAndTitleContaining(Long projectId,
+        Long progressStepId, String title, Pageable pageable);
 
-    Page<Question> findByProjectIdAndStatusAndTitleContaining(Long projectId, Status status, String title, Pageable pageable);
+    Page<Question> findByProjectIdAndStatusAndTitleContaining(Long projectId, Status status,
+        String title, Pageable pageable);
 
-    Page<Question> findByProjectIdAndProgressStepIdAndStatusAndTitleContaining(Long projectId, Long progressStepId, Status status, String title, Pageable pageable);
+    Page<Question> findByProjectIdAndProgressStepIdAndStatusAndTitleContaining(Long projectId,
+        Long progressStepId, Status status, String title, Pageable pageable);
 
     Long countByProjectId(Long projectId);
 

--- a/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/question/QuestionRepository.java
@@ -47,5 +47,5 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     Long countByProjectIdAndProgressStepId(Long projectId, Long progressStepId);
 
-    boolean existsByIdAndProjectId(Long id, Long projectId);
+    boolean existsByProjectIdAndId(Long projectId, Long id);
 }

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionGet.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionGet.java
@@ -1,0 +1,95 @@
+package com.checkping.dto.question;
+
+import com.checkping.domain.question.Question;
+import com.checkping.domain.question.Question.Category;
+import com.checkping.domain.question.Question.Status;
+import com.checkping.dto.question.comment.QuestionCommentGet;
+import com.checkping.dto.question.file.QuestionFileRegister;
+import com.checkping.dto.question.link.QuestionLinkRegister;
+import com.checkping.exception.question.QuestionContentParsingException;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class QuestionGet {
+
+    public static class Response {
+
+        /*
+        id : 게시글 고유 ID
+        number : 게시글 번호
+        title : 게시글 제목
+        content : 게시글 본문 내용
+        regAt : 게시글 작성 일시
+        editAt : 게시글 마지막 수정 일시
+        category : 게시글 카테고리 (enum, String)
+        status : 게시글 상태 (enum, String)
+        commentList : 게시글 댓글 리스트
+        linkList : 게시글 첨부 링크 리스트
+        fileList : 게시글 첨부 파일 리스트
+         */
+        @Schema(description = "게시글 번호")
+        private Long id;
+        @Schema(description = "게시글 번호")
+        private Integer number;
+        @Schema(description = "게시글 제목", example = "게시글 제목 입니다.")
+        private String title;
+        @Schema(description = "게시글 본문", example = "게시글 본문 입니다.")
+        private List<QuestionContent> content;
+        @Schema(description = "등록 일시")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime regAt;
+        @Schema(description = "수정 일시")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime editAt;
+        @Schema(description = "게시글 유형")
+        private Category category;
+        @Schema(description = "게시글 상태")
+        private Status status;
+        @Schema(description = "게시글 댓글 목록")
+        private List<QuestionCommentGet.Response> commentList;
+        @Schema(description = "게시글 첨부 링크 목록")
+        private List<QuestionLinkRegister.Response> linkList;
+        @Schema(description = "게시글 첨부 파일 목록")
+        private List<QuestionFileRegister.Response> fileList;
+
+        public static Response toDto(Question question) {
+            Response response = new Response();
+            response.id = question.getId();
+            response.number = question.getNumber();
+            response.title = question.getTitle();
+            response.content = QuestionGet.Response.toContentList(question.getContent());
+            response.regAt = question.getRegAt();
+            response.editAt = question.getEditAt();
+            response.category = question.getCategory();
+            response.status = question.getStatus();
+            response.commentList = QuestionCommentGet.Response.toDto(question.getCommentList());
+            response.linkList = QuestionLinkRegister.Response.toDto(question.getQuestionLinkList());
+            response.fileList = QuestionFileRegister.Response.toDto(question.getQuestionFileList());
+            return response;
+        }
+
+        /**
+         * String -> JSON LIST
+         *
+         * @param content content String
+         * @return content List
+         */
+        private static List<QuestionContent> toContentList(String content) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            try {
+                return objectMapper.readValue(content, new TypeReference<List<QuestionContent>>() {
+                });
+            } catch (Exception e) {
+                throw new QuestionContentParsingException();
+            }
+        }
+    }
+
+}

--- a/module-service/src/main/java/com/checkping/dto/question/QuestionGet.java
+++ b/module-service/src/main/java/com/checkping/dto/question/QuestionGet.java
@@ -14,11 +14,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class QuestionGet {
 
+    @Getter
     public static class Response {
 
         /*

--- a/module-service/src/main/java/com/checkping/dto/question/comment/QuestionCommentGet.java
+++ b/module-service/src/main/java/com/checkping/dto/question/comment/QuestionCommentGet.java
@@ -1,0 +1,64 @@
+package com.checkping.dto.question.comment;
+
+import com.checkping.common.utils.DateTimeUtils;
+import com.checkping.domain.question.QuestionComment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class QuestionCommentGet {
+
+    @Getter
+    public static class Response {
+
+        /*
+        id : 질문 게시글 댓글 아이디
+        content : 댓글 내용
+        regAt : 작성 일시
+        editAt : 수정 일시
+        parentId : 부모 댓글 아이디
+         */
+        @Schema(description = "질문 게시글 댓글 아이디")
+        private Long id;
+        @Schema(description = "질문 게시글 댓글 내용")
+        private String content;
+        @Schema(description = "질문 게시글 댓글 작성 일시")
+        private String regAt;
+        @Schema(description = "질문 게시글 댓글 수정 일시")
+        private String editAt;
+        @Schema(description = "질문 게시글 댓글 부모 댓글 아이디")
+        private Long parentId;
+
+        /**
+         * 질문 게시글 댓글 엔티티를 응답 정보로 변환하는 메서드
+         *
+         * @param comment 질문 게시글 댓글 엔티티
+         * @return 질문 게시글 댓글 응답 정보
+         */
+        public static Response toDto(QuestionComment comment) {
+            Response response = new Response();
+            response.id = comment.getId();
+            response.content = comment.getContent();
+            response.regAt = DateTimeUtils.format(comment.getRegAt());
+            response.editAt = DateTimeUtils.format(comment.getEditAt());
+            response.parentId = comment.getParent() == null ? null : comment.getParent().getId();
+            return response;
+        }
+
+        /**
+         * 질문 게시글 댓글 엔티티 리스트를 응답 정보 리스트로 변환하는 메서드
+         *
+         * @param comments 질문 게시글 댓글 엔티티 리스트
+         * @return 질문 게시글 댓글 응답 정보 리스트
+         */
+        public static List<Response> toDto(List<QuestionComment> comments) {
+            return comments.stream()
+                .map(Response::toDto)
+                .toList();
+        }
+    }
+
+}

--- a/module-service/src/main/java/com/checkping/dto/question/comment/QuestionCommentGet.java
+++ b/module-service/src/main/java/com/checkping/dto/question/comment/QuestionCommentGet.java
@@ -2,12 +2,15 @@ package com.checkping.dto.question.comment;
 
 import com.checkping.common.utils.DateTimeUtils;
 import com.checkping.domain.question.QuestionComment;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@JsonInclude(Include.ALWAYS)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class QuestionCommentGet {
 
@@ -20,6 +23,7 @@ public class QuestionCommentGet {
         regAt : 작성 일시
         editAt : 수정 일시
         parentId : 부모 댓글 아이디
+        isParent : 부모 댓글인지 여부 체크 T/F
          */
         @Schema(description = "질문 게시글 댓글 아이디")
         private Long id;
@@ -31,7 +35,8 @@ public class QuestionCommentGet {
         private String editAt;
         @Schema(description = "질문 게시글 댓글 부모 댓글 아이디")
         private Long parentId;
-
+        @Schema(description = "부모 댓글인지 여부 체크 T/F")
+        private boolean isParent;
         /**
          * 질문 게시글 댓글 엔티티를 응답 정보로 변환하는 메서드
          *
@@ -44,7 +49,15 @@ public class QuestionCommentGet {
             response.content = comment.getContent();
             response.regAt = DateTimeUtils.format(comment.getRegAt());
             response.editAt = DateTimeUtils.format(comment.getEditAt());
-            response.parentId = comment.getParent() == null ? null : comment.getParent().getId();
+            response.parentId = null;
+            response.isParent = true;
+
+            // 부모 댓글이 있는 경우
+            if (comment.getParent() != null) {
+                response.parentId = comment.getParent().getId();
+                response.isParent = false;
+            }
+
             return response;
         }
 
@@ -58,6 +71,17 @@ public class QuestionCommentGet {
             return comments.stream()
                 .map(Response::toDto)
                 .toList();
+        }
+
+        /**
+         * 질문 게시글이 부모 댓글인지 여부를 반환한다.
+         * 부모 댓글인 경우 true, 자식 댓글인 경우 false를 반환한다.
+         * JackSon 라이브러리가 isParent 필드를 인식하도록 하기 위해 get 메서드를 추가한다.
+         *
+         * @return 부모 댓글인지 여부
+         */
+        public boolean getIsParent() {
+            return isParent;
         }
     }
 

--- a/module-service/src/main/java/com/checkping/service/question/QuestionService.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionService.java
@@ -1,6 +1,7 @@
 package com.checkping.service.question;
 
 import com.checkping.dto.question.QuestionCounter;
+import com.checkping.dto.question.QuestionGet;
 import com.checkping.dto.question.QuestionRegister;
 import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest.UpdateDto;
@@ -17,7 +18,7 @@ public interface QuestionService {
     QuestionSearch.Response searchQuestions(Long projectId,
         QuestionSearchCondition searchCondition);
 
-    QuestionItemDto getById(Long questionId);
+    QuestionGet.Response getById(Long questionId);
 
     QuestionListDto deleteSoft(Long taskBoardId);
 

--- a/module-service/src/main/java/com/checkping/service/question/QuestionService.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionService.java
@@ -17,7 +17,7 @@ public interface QuestionService {
     QuestionSearch.Response searchQuestions(Long projectId,
         QuestionSearchCondition searchCondition);
 
-    QuestionItemDto getQuestionById(Long taskBoardId);
+    QuestionItemDto getById(Long questionId);
 
     QuestionListDto deleteSoft(Long taskBoardId);
 

--- a/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
@@ -6,6 +6,7 @@ import com.checkping.domain.question.QuestionComment;
 import com.checkping.domain.question.QuestionFile;
 import com.checkping.domain.question.QuestionLink;
 import com.checkping.dto.question.QuestionCounter;
+import com.checkping.dto.question.QuestionGet;
 import com.checkping.dto.question.QuestionRegister;
 import com.checkping.dto.question.QuestionRegister.Request;
 import com.checkping.dto.question.QuestionRequest.UpdateDto;
@@ -107,14 +108,14 @@ public class QuestionServiceImpl implements QuestionService {
      * @return QuestionListDto
      */
     @Override
-    public QuestionItemDto getById(Long questionId) {
+    public QuestionGet.Response getById(Long questionId) {
 
         // find Question Entity
         Question question = questionReader.getQuestionById(questionId)
             .orElseThrow(QuestionNotFoundEntityException::new);
 
         // Entity -> Dto
-        return QuestionItemDto.toDto(question);
+        return QuestionGet.Response.toDto(question);
     }
 
     /**

--- a/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -107,6 +108,7 @@ public class QuestionServiceImpl implements QuestionService {
      * @param questionId 업무 관리 게시글 ID
      * @return QuestionListDto
      */
+    @Transactional(readOnly = true)
     @Override
     public QuestionGet.Response getById(Long questionId) {
 

--- a/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
@@ -111,7 +111,7 @@ public class QuestionServiceImpl implements QuestionService {
     public QuestionGet.Response getById(Long questionId) {
 
         // find Question Entity
-        Question question = questionReader.getQuestionById(questionId)
+        Question question = questionReader.getById(questionId)
             .orElseThrow(QuestionNotFoundEntityException::new);
 
         // Entity -> Dto
@@ -128,7 +128,7 @@ public class QuestionServiceImpl implements QuestionService {
     public QuestionListDto deleteSoft(Long taskBoardId) {
 
         // find Question Entity
-        Question initQuestion = questionReader.getQuestionById(taskBoardId)
+        Question initQuestion = questionReader.getById(taskBoardId)
             .orElseThrow(QuestionNotFoundEntityException::new);
 
         // QuestionComment - SOFT DELETE
@@ -158,7 +158,7 @@ public class QuestionServiceImpl implements QuestionService {
     public QuestionListDto deleteHard(Long taskBoardId) {
 
         // find Question Entity
-        Question initQuestion = questionReader.getQuestionById(taskBoardId)
+        Question initQuestion = questionReader.getById(taskBoardId)
             .orElseThrow(QuestionNotFoundEntityException::new);
 
         // QuestionComment - HARD DELETE
@@ -184,7 +184,7 @@ public class QuestionServiceImpl implements QuestionService {
     public QuestionItemDto update(Long taskBoardId, UpdateDto request) {
 
         // find Question Entity
-        Question initQuestion = questionReader.getQuestionById(taskBoardId)
+        Question initQuestion = questionReader.getById(taskBoardId)
             .orElseThrow(QuestionNotFoundEntityException::new);
 
         // update

--- a/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
@@ -103,14 +103,14 @@ public class QuestionServiceImpl implements QuestionService {
     /**
      * 업무 관리 게시글 서비스 - 상세 조회
      *
-     * @param taskBoardId 업무 관리 게시글 ID
+     * @param questionId 업무 관리 게시글 ID
      * @return QuestionListDto
      */
     @Override
-    public QuestionItemDto getQuestionById(Long taskBoardId) {
+    public QuestionItemDto getById(Long questionId) {
 
         // find Question Entity
-        Question question = questionReader.getQuestionById(taskBoardId)
+        Question question = questionReader.getQuestionById(questionId)
             .orElseThrow(QuestionNotFoundEntityException::new);
 
         // Entity -> Dto

--- a/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/QuestionServiceImpl.java
@@ -111,7 +111,7 @@ public class QuestionServiceImpl implements QuestionService {
     public QuestionGet.Response getById(Long questionId) {
 
         // find Question Entity
-        Question question = questionReader.getById(questionId)
+        Question question = questionReader.getByIdWithComments(questionId)
             .orElseThrow(QuestionNotFoundEntityException::new);
 
         // Entity -> Dto

--- a/module-service/src/main/java/com/checkping/service/question/comment/QuestionCommentServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/comment/QuestionCommentServiceImpl.java
@@ -178,7 +178,7 @@ public class QuestionCommentServiceImpl implements QuestionCommentService {
      * @param questionId 질문 Id
      */
     private void containingProject(Long projectId, Long questionId) {
-        boolean isContaining = questionReader.checkQuestionContaining(projectId, questionId);
+        boolean isContaining = questionReader.checkQuestionContaining(questionId, projectId);
         if (!isContaining) {
             throw new QuestionNotFoundEntityException();
         }
@@ -191,8 +191,8 @@ public class QuestionCommentServiceImpl implements QuestionCommentService {
      * @param questionCommentId 질문 댓글 Id
      */
     private void containingComment(Long questionId, Long questionCommentId) {
-        boolean isContaining = questionCommentReader.checkCommentContaining(questionId,
-            questionCommentId);
+        boolean isContaining = questionCommentReader.checkCommentContaining(
+            questionCommentId, questionId);
         if (!isContaining) {
             throw new QuestionCommentMisMatchEntityException();
         }

--- a/module-service/src/main/java/com/checkping/service/question/comment/QuestionCommentServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/comment/QuestionCommentServiceImpl.java
@@ -37,7 +37,7 @@ public class QuestionCommentServiceImpl implements QuestionCommentService {
         Long projectId, QuestionCommentRegister.Request request) {
 
         // find Question Entity
-        Question question = questionReader.getQuestionById(projectId).orElseThrow(
+        Question question = questionReader.getById(projectId).orElseThrow(
             QuestionNotFoundEntityException::new);
 
         // Dto -> Entity
@@ -68,7 +68,7 @@ public class QuestionCommentServiceImpl implements QuestionCommentService {
         containingProject(projectId, questionId);
 
         // find Question Entity
-        Question question = questionReader.getQuestionById(questionId).orElseThrow(
+        Question question = questionReader.getById(questionId).orElseThrow(
             QuestionNotFoundEntityException::new);
 
         // Check Question contain Comment

--- a/module-service/src/main/java/com/checkping/service/question/comment/QuestionCommentServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/comment/QuestionCommentServiceImpl.java
@@ -178,8 +178,7 @@ public class QuestionCommentServiceImpl implements QuestionCommentService {
      * @param questionId 질문 Id
      */
     private void containingProject(Long projectId, Long questionId) {
-        boolean isContaining = questionReader.checkQuestionContaining(questionId, projectId);
-        if (!isContaining) {
+        if (!questionReader.checkQuestionContaining(projectId, questionId)) {
             throw new QuestionNotFoundEntityException();
         }
     }

--- a/module-service/src/main/java/com/checkping/service/question/file/QuestionFileServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/file/QuestionFileServiceImpl.java
@@ -21,7 +21,7 @@ public class QuestionFileServiceImpl implements QuestionFileService {
     @Override
     public List<FileResponse> saveFiles(Long taskBoardId, List<MultipartFile> fileRequests) {
 
-        Question question = questionReader.getQuestionById(taskBoardId).orElseThrow(
+        Question question = questionReader.getById(taskBoardId).orElseThrow(
             QuestionNotFoundEntityException::new);
 
         List<QuestionFile> files = questionFileStore.saveFileList(question, fileRequests);

--- a/module-service/src/main/java/com/checkping/service/question/link/QuestionLinkServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/question/link/QuestionLinkServiceImpl.java
@@ -29,7 +29,7 @@ public class QuestionLinkServiceImpl implements QuestionLinkService {
         QuestionLinkRequest.RegisterDto request) {
 
         // find Question Entity
-        Question question = questionReader.getQuestionById(taskBoardId).orElseThrow(
+        Question question = questionReader.getById(taskBoardId).orElseThrow(
             QuestionNotFoundEntityException::new);
 
         // Dto -> Entity


### PR DESCRIPTION
# 🚀 Pull Request

**[질문 게시글 상세 조회 추가 기능]**

## #️⃣ 연관된 이슈

- #290 

## 📋 작업 내용

```java
@Query("SELECT q FROM Question q " +
        "LEFT JOIN FETCH q.commentList c " +
        "WHERE q.id = :questionId " +
        "ORDER BY COALESCE(c.parent.id, c.id) , c.regAt ASC")
Optional<Question> findByIdWithComments(@Param("questionId") Long id);
```
댓글 ID 가 1 인 댓글에 대댓글이 4, 5 가 달리고 댓글 ID 가 3 인 댓글에 6 이 달리는 경우
댓글이 1 -> 4 -> 5 -> 2 -> 3 -> 6 순으로 조회되도록 하였습니다.
