### PR TITLE
315 feature 고객 별 프로젝트 목록 조회 조건 추가

### DIFF
--- a/module-infra/src/main/java/com/checkping/infra/dto/ProjectDetailsDto.java
+++ b/module-infra/src/main/java/com/checkping/infra/dto/ProjectDetailsDto.java
@@ -1,10 +1,12 @@
 package com.checkping.infra.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.Date;
 
 @Getter
+@AllArgsConstructor
 public class ProjectDetailsDto {
     private final Long id;
     private final String projectName;
@@ -17,21 +19,4 @@ public class ProjectDetailsDto {
     private final String phoneNum;
     private final Date startAt;
     private final Date closeAt;
-
-    public ProjectDetailsDto(Long id, String projectName, String description, String devOrgName,
-                             String profileImageUrl, String memberName, String jobRole, String jobTitle,
-                             String phoneNum, Date startAt, Date closeAt) {
-        this.id = id;
-        this.projectName = projectName;
-        this.description = description;
-        this.devOrgName = devOrgName;
-        this.profileImageUrl = profileImageUrl;
-        this.memberName = memberName;
-        this.jobRole = jobRole;
-        this.jobTitle = jobTitle;
-        this.phoneNum = phoneNum;
-        this.startAt = startAt;
-        this.closeAt = closeAt;
-    }
-
 }

--- a/module-infra/src/main/java/com/checkping/infra/dto/ProjectListDetailsDto.java
+++ b/module-infra/src/main/java/com/checkping/infra/dto/ProjectListDetailsDto.java
@@ -1,0 +1,28 @@
+package com.checkping.infra.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectListDetailsDto {
+    private Long id;
+    private String name;
+    private String description;
+    private String detail;
+    private String status;
+    private String managementStep;
+    private Date regAt;
+    private Date updateAt;
+    private Date startAt;
+    private Date closeAt;
+    private String deletedYn;
+    private Long devOwnerId;
+    private String developerName;
+    private String customerName;
+    private Long clickable;
+}

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectRepository.java
@@ -2,6 +2,7 @@ package com.checkping.infra.repository.project;
 
 import com.checkping.domain.project.Project;
 import com.checkping.infra.dto.ProjectDetailsDto;
+import com.checkping.infra.dto.ProjectListDetailsDto;
 import com.checkping.infra.dto.ProjectUpdateDetailsDto;
 import com.checkping.infra.repository.project.projection.ProjectInfoProjection;
 import jakarta.persistence.Tuple;
@@ -16,17 +17,15 @@ import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
 
-    @Query(value = "SELECT p.*, " +
-            "org_info.developer_type, " +
-            "org_info.developer_name, " +
-            "org_info.customer_type, " +
-            "org_info.customer_name " +
+    @Query(value =
+            "SELECT " +
+            "p.id, p.name, p.description, p.detail, p.status, p.management_step, " +
+            "p.reg_at, p.update_at, p.start_at, p.close_at, p.deleted_yn, p.dev_owner_id, " +
+            "org_info.developer_name, org_info.customer_name, 1 AS clickable " +
             "FROM project p " +
             "LEFT JOIN ( " +
             "    SELECT obp.project_id, " +
-            "    MAX(CASE WHEN o.type = 'DEVELOPER' THEN o.type END) AS developer_type, " +
             "    MAX(CASE WHEN o.type = 'DEVELOPER' THEN o.name END) AS developer_name, " +
-            "    MAX(CASE WHEN o.type = 'CUSTOMER' THEN o.type END) AS customer_type, " +
             "    MAX(CASE WHEN o.type = 'CUSTOMER' THEN o.name END) AS customer_name " +
             "    FROM organization_by_project obp " +
             "    LEFT JOIN organization o ON obp.org_id = o.id " +
@@ -34,7 +33,58 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
             ") AS org_info ON p.id = org_info.project_id " +
             "WHERE (NULLIF(:keyword, '') IS NULL OR p.name LIKE CONCAT('%', :keyword, '%')) " +
             "AND (NULLIF(:status, '') IS NULL OR p.status = :status)", nativeQuery = true)
-    Page<Project> findProjectsWithOrganizationInfoByKeywordAndStatus(@Param("keyword") String keyword, @Param("status") String status, @Param("pageable") Pageable pageable);
+    Page<ProjectListDetailsDto> findAdminProjectsByKeywordAndStatus(@Param("keyword") String keyword, @Param("status") String status, @Param("pageable") Pageable pageable);
+
+    @Query(value =
+            "SELECT " +
+            "p.id, p.name, p.description, p.detail, p.status, p.management_step, " +
+            "p.reg_at, p.update_at, p.start_at, p.close_at, p.deleted_yn, p.dev_owner_id, " +
+            "org_info.developer_name, org_info.customer_name, " +
+            "CASE " +
+            "   WHEN EXISTS (" +
+            "   SELECT 1 " +
+            "   FROM member_by_project mbp " +
+            "   WHERE mbp.project_id = obp.project_id " +
+            "   AND mbp.member_id = m.id " +
+            "   ) THEN 1 " +
+            "   ELSE 0 " +
+            "END AS clickable " +
+            "FROM project p " +
+            "LEFT JOIN organization_by_project obp on p.id = obp.project_id " +
+            "LEFT JOIN organization o on obp.org_id = o.id " +
+            "LEFT JOIN member m on o.id = m.org_id " +
+            "LEFT JOIN (" +
+            "    SELECT mbp.project_id, " +
+            "    MAX(CASE WHEN o.type = 'DEVELOPER' THEN o.name END) AS developer_name, " +
+            "    MAX(CASE WHEN o.type = 'CUSTOMER' THEN o.name END) AS customer_name " +
+            "    FROM member_by_project mbp " +
+            "    LEFT JOIN member m ON mbp.member_id = m.id " +
+            "    LEFT JOIN organization o ON m.org_id = o.id " +
+            "    GROUP BY mbp.project_id " +
+            ") AS org_info ON p.id = org_info.project_id " +
+            "WHERE m.id = :memberId ", nativeQuery = true)
+    Page<ProjectListDetailsDto> findDeveloperProjectsByKeywordAndStatus(@Param("keyword") String keyword, @Param("status") String status, @Param("pageable") Pageable pageable, @Param("memberId") Long memberId);
+
+    @Query(value =
+            "SELECT " +
+            "p.id, p.name, p.description, p.detail, p.status, p.management_step, " +
+            "p.reg_at, p.update_at, p.start_at, p.close_at, p.deleted_yn, p.dev_owner_id, " +
+            "org_info.developer_name, org_info.customer_name, 1 AS clickable " +
+            "FROM project p " +
+            "LEFT JOIN member_by_project mbp ON p.id = mbp.project_id " +
+            "LEFT JOIN member m ON mbp.member_id = m.id " +
+            "LEFT JOIN ( " +
+            "    SELECT mbp.project_id, " +
+            "    MAX(CASE WHEN o.type = 'DEVELOPER' THEN o.name END) AS developer_name, " +
+            "    MAX(CASE WHEN o.type = 'CUSTOMER' THEN o.name END) AS customer_name " +
+            "    FROM member_by_project mbp " +
+            "    LEFT JOIN member m ON mbp.member_id = m.id " +
+            "    LEFT JOIN organization o ON m.org_id = o.id " +
+            "    GROUP BY mbp.project_id " +
+            ") AS org_info ON p.id = org_info.project_id " +
+            "WHERE m.id = :memberId ", nativeQuery = true)
+    Page<ProjectListDetailsDto> findCustomerProjectsByKeywordAndStatus(@Param("keyword") String keyword, @Param("status") String status, @Param("pageable") Pageable pageable, @Param("memberId") Long memberId);
+
 
     @Query("SELECT p.managementStep, COUNT(p) AS projectCount " +
             "FROM Project p " +

--- a/module-service/src/main/java/com/checkping/dto/project/ProjectResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/project/ProjectResponse.java
@@ -4,6 +4,7 @@ package com.checkping.dto.project;
 import com.checkping.common.dto.PageMetaResponse;
 import com.checkping.domain.project.Project;
 import com.checkping.infra.dto.ProjectDetailsDto;
+import com.checkping.infra.dto.ProjectListDetailsDto;
 import com.checkping.infra.dto.ProjectUpdateDetailsDto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -137,21 +138,83 @@ public class ProjectResponse {
     }
 
     @Getter
+    @ToString
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProjectListDetailDto {
+        @Schema(description = "프로젝트 아이디")
+        private Long id;
+        @Schema(description = "프로젝트 이름")
+        private String name;
+        @Schema(description = "프로젝트 짧은 설명")
+        private String description;
+        @Schema(description = "프로젝트 긴 설명")
+        private String detail;
+        @Schema(description = "프로젝트 상태")
+        private Project.Status status;
+        @Schema(description = "프로젝트 관리 단계")
+        private Project.ManagementStep managementStep;
+        @Schema(description = "프로젝트 등록 일시")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private Date regAt;
+        @Schema(description = "프로젝트 수정 일시")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private Date updateAt;
+        @Schema(description = "프로젝트 시작 일시")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private Date startAt;
+        @Schema(description = "프로젝트 마감 일시")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private Date closeAt;
+        @Schema(description = "프로젝트 삭제여부")
+        private String deletedYn;
+        @Schema(description = "개발사 대표자 아이디")
+        private Long devOwnerId;
+        @Schema(description = "개발사 이름")
+        private String developerName;
+        @Schema(description = "고객사 이름")
+        private String customerName;
+        @Schema(description = "프로젝트 클릭 가능 여부")
+        private Long clickable;
+
+        public static ProjectListDetailDto toDto(ProjectListDetailsDto dto) {
+            return ProjectListDetailDto.builder()
+                    .id(dto.getId())
+                    .name(dto.getName())
+                    .description(dto.getDescription())
+                    .detail(dto.getDetail())
+                    .status(Project.Status.valueOf(dto.getStatus()))
+                    .managementStep(Project.ManagementStep.valueOf(dto.getManagementStep()))
+                    .regAt(dto.getRegAt())
+                    .updateAt(dto.getUpdateAt())
+                    .startAt(dto.getStartAt())
+                    .closeAt(dto.getCloseAt())
+                    .deletedYn(dto.getDeletedYn())
+                    .devOwnerId(dto.getDevOwnerId())
+                    .developerName(dto.getDeveloperName())
+                    .customerName(dto.getCustomerName())
+                    .clickable(dto.getClickable())
+                    .build();
+        }
+    }
+
+    @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ProjectListDto {
-        private List<ProjectDto> projects;
+        private List<ProjectListDetailDto> projects;
         private Map<String, Object> meta;
 
+        public static ProjectListDto fromEntityPage(Page<ProjectListDetailsDto> page) {
 
-        public static ProjectListDto fromEntityPage(Page<Project> page) {
-            List<ProjectResponse.ProjectDto> projectDtos = page.getContent().stream()
-                    .map(ProjectResponse.ProjectDto::toDto)
+            List<ProjectListDetailDto> projectDtos = page.getContent().stream()
+                    .map(ProjectResponse.ProjectListDetailDto::toDto)
                     .toList();
 
             PageMetaResponse meta = PageMetaResponse.fromPage(page);
-            Map<String, Object> result =  meta.toMap();
+            Map<String, Object> result = meta.toMap();
 
             return new ProjectListDto(projectDtos, result);
         }

--- a/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
@@ -7,6 +7,7 @@ import com.checkping.domain.member.Organization;
 import com.checkping.domain.project.ProgressStep;
 import com.checkping.domain.project.Project;
 import com.checkping.dto.project.ProjectResponse;
+import com.checkping.infra.dto.ProjectListDetailsDto;
 import com.checkping.infra.dto.ProjectUpdateDetailsDto;
 import com.checkping.infra.repository.member.MemberRepository;
 import com.checkping.infra.repository.member.OrganizationRepository;
@@ -16,6 +17,7 @@ import com.checkping.infra.repository.project.projection.ProjectInfoProjection;
 import com.checkping.infra.repository.project.ProjectRepository;
 import com.checkping.dto.project.ProjectRequest;
 
+import com.checkping.service.member.util.CurrentMemberUtil;
 import io.micrometer.common.util.StringUtils;
 import jakarta.persistence.Tuple;
 import jakarta.transaction.Transactional;
@@ -42,6 +44,7 @@ public class ProjectServiceImpl implements ProjectService {
     private final OrganizationRepository organizationRepository;
     private final MemberRepository memberRepository;
     private final ProgressStepRepository progressStepRepository;
+    private final CurrentMemberUtil currentMemberUtil;
 
     @Override
     @Transactional
@@ -125,11 +128,30 @@ public class ProjectServiceImpl implements ProjectService {
     @Override
     public ProjectResponse.ProjectListDto findAllProjects(String keyword, String status, int page, int size) {
         Pageable pageable = PageRequest.of(page-1, size, Sort.Direction.DESC, "id");
+        Member member = currentMemberUtil.getCurrentMember();
 
-        Page<Project> results = projectRepository.findProjectsWithOrganizationInfoByKeywordAndStatus(
-            keyword, status, pageable);
+        Page<ProjectListDetailsDto> results = getProjectListByRoleAndType(member, keyword, status, pageable);
 
         return ProjectResponse.ProjectListDto.fromEntityPage(results);
+    }
+
+    private Page<ProjectListDetailsDto> getProjectListByRoleAndType(Member member, String keyword, String status, Pageable pageable) {
+        Member.Role role = member.getRole();
+
+        if (role.equals(Member.Role.ADMIN)) {
+            return projectRepository.findAdminProjectsByKeywordAndStatus(keyword, status, pageable);
+        }
+
+        Organization.Type type = member.getOrganization().getType();
+        Long memberId = member.getId();
+
+        if (type == Organization.Type.DEVELOPER) {
+            return projectRepository.findDeveloperProjectsByKeywordAndStatus(keyword, status, pageable, memberId);
+        } else if (type == Organization.Type.CUSTOMER) {
+            return projectRepository.findCustomerProjectsByKeywordAndStatus(keyword, status, pageable, memberId);
+        }
+
+        return Page.empty(pageable);
     }
 
     @Override


### PR DESCRIPTION
# 🚀 Pull Request

 고객 별 프로젝트 목록 조회 조건 추가

## #️⃣ 연관된 이슈

#315

## 📋 작업 내용

- 관리자/개발사/고객사에 따라 프로젝트 목록 조회하는 네이티브 SQL 쿼리 추가
  - 관리자
    -  모든 프로젝트의 목록 조회, 모든 프로젝트 클릭 가능
  - 개발사
    -  자신이 속한 업체의 모든 프로젝트의 목록 조회, 자신이 담당한 프로젝트만 클릭 가능
  - 고객사
    -  자신이 담당한 프로젝트만 목록 조회, 자신이 담당한 프로젝트만 클릭 가능
 
- 현재 사용자가 클릭 가능한 프로젝트일 경우, clickable=1
  - 관리자, 고객사는 모든 프로젝트의 clickable=1 / 개발사는 클릭 가능한 프로젝트일 경우만 1, 아닐 경우 0
