### PR TITLE
chore : 엑세스 토큰 검증 시, 응답 값 수정

### DIFF
--- a/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
@@ -30,7 +30,6 @@ public class JWTFilter extends OncePerRequestFilter {
 
         this.jwtUtil = jwtUtil;
     }
-
     // TODO 필터 거치지 않을 경로 설정
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
@@ -53,11 +52,6 @@ public class JWTFilter extends OncePerRequestFilter {
         return false;
     }
 
-
-    /*
-    TODO
-     #1. 권한이 필요한 요청인데 토큰이 없는 경우 - Spring Security가 기본적으로 처리
-     #2. 권한이 필요 없는 경우에도 만료된 토큰이 들어오면 접근 차단하는 문제 해결*/
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         // 쿠키에서 토큰 추출
@@ -66,8 +60,10 @@ public class JWTFilter extends OncePerRequestFilter {
         // 쿠키가 없는 경우
         if (cookies == null) {
 
-            BaseResponse<Void> errorResponse = BaseResponse.fail(ErrorCode.UNAUTHORIZED);
+            BaseResponse<Void> errorResponse = BaseResponse.fail(ErrorCode.COOKIES_NOT_FOUND);
             ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
             return;
         }
 
@@ -89,8 +85,9 @@ public class JWTFilter extends OncePerRequestFilter {
             jwtUtil.isExpired(accessToken);
         } catch (ExpiredJwtException e) {
 
-            String errorMessage = "access token expired";
-            ResponseUtil.sendErrorResponse(response, HttpStatus.valueOf(HttpServletResponse.SC_UNAUTHORIZED), errorMessage);
+            BaseResponse<Void> errorResponse = BaseResponse.fail(ErrorCode.EXPIRED_JWT_ACCESS_TOKEN);
+            ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
+
             return;
         }
 

--- a/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
+++ b/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     INVALID_LOGIN_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일(로그인 전용 이메일) 또는 비밀번호를 잘못 입력했습니다." + "입력하신 내용을 다시 확인해주세요."),
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다. 이메일 또는 비밀번호를 다시 확인하세요."),
     LOGOUT_FAILURE(HttpStatus.UNAUTHORIZED, "로그인된 사용자가 아닙니다.\n 로그아웃에 실패하였습니다."),
+    COOKIES_NOT_FOUND(HttpStatus.UNAUTHORIZED, "쿠키를 찾을 수 없습니다."),
 
     /*
         403 Forbidden


### PR DESCRIPTION
# 🚀 Pull Request

> 응답 형식이 달라 토큰 재발급이 안되던 버그 수정

## #️⃣ 연관된 이슈

#347

## 📋 작업 내용

JWTFilter.java :
쿠키가 없는 경우, 만료된 경우
BaseResponse형삭에 맞게 응답값 수정

ErrorCode.java:
ErrorCode.COOKIES_NOT_FOUND 에러코드 추가
