### PR TITLE
Feature/327 레디스 엘라스틱캐시 토큰 블랙리스트 구현

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     implementation project(':module-service')

--- a/module-api/src/main/java/com/checkping/api/auth/config/CustomSecurityConfig.java
+++ b/module-api/src/main/java/com/checkping/api/auth/config/CustomSecurityConfig.java
@@ -1,12 +1,14 @@
 package com.checkping.api.auth.config;
 
 import com.checkping.api.auth.filter.JWTFilter;
+import com.checkping.service.member.auth.TokenBlacklistService;
 import com.checkping.service.member.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.server.CookieSameSiteSupplier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
@@ -24,24 +26,18 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity
+@RequiredArgsConstructor
 public class CustomSecurityConfig {
 
     //AuthenticationManager가 인자로 받을 AuthenticationConfiguraion 객체 생성자 주입
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtUtil jwtUtil;
-
-    public CustomSecurityConfig(AuthenticationConfiguration authenticationConfiguration,
-        JwtUtil jwtUtil) {
-
-        this.authenticationConfiguration = authenticationConfiguration;
-        this.jwtUtil = jwtUtil;
-    }
+    private final TokenBlacklistService tokenBlacklistService;
 
     //AuthenticationManager Bean 등록
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
-        throws Exception {
+            throws Exception {
 
         return configuration.getAuthenticationManager();
     }
@@ -63,25 +59,22 @@ public class CustomSecurityConfig {
         http.logout(logout->logout.disable());
 
         http.headers(
-            headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
+                headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
 
         //경로별 인가 작업
         http.authorizeHttpRequests((auth) -> auth
                 .requestMatchers("/login").permitAll()
                 .requestMatchers("/reissue").permitAll()
-                .requestMatchers("/check").permitAll()
                 .requestMatchers("/admins/**").hasRole("ADMIN")
                 .requestMatchers("/swagger-ui/**").permitAll()
                 .requestMatchers("/v3/api-docs/**").permitAll()
                 .anyRequest().authenticated());
-//                .anyRequest().permitAll()); // TODO MVP에서는 일단 모든 경로 권한 필요 없음, 추후 경로 별 권한 설정
 
-        //기능 테스트 위해서 일시적인 주석처리 2025/01/15
-        http.addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new JWTFilter(jwtUtil,tokenBlacklistService), UsernamePasswordAuthenticationFilter.class);
 
         //세션 설정
         http.sessionManagement(
-            (session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+                (session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
     }
@@ -92,15 +85,21 @@ public class CustomSecurityConfig {
         configuration.setAllowedMethods(Collections.singletonList("*"));
 //        configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
         configuration.setAllowedOrigins(
-            List.of("https://www.flowssync.com", "http://localhost:3000", "http://localhost:8080",
-                "https://dev.flowssync.com", "https://api.flowssync.com",
-                "https://test.flowssync.com", "https://prod.flowssync.com"));
+                List.of("https://www.flowssync.com", "http://localhost:3000", "http://localhost:8080",
+                        "https://dev.flowssync.com", "https://api.flowssync.com",
+                        "https://test.flowssync.com"));
         configuration.setAllowCredentials(true);
         configuration.setAllowedHeaders(Collections.singletonList("*"));
         configuration.setExposedHeaders(
-            Arrays.asList("Authorization", "Content-Type", "Content-Disposition"));
+                Arrays.asList("Authorization", "Content-Type", "Content-Disposition", "Set-Cookie"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }
+
+    @Bean
+    public CookieSameSiteSupplier cookieSameSiteSupplier() {
+        return CookieSameSiteSupplier.ofNone();
+    }
+
 }

--- a/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
@@ -5,13 +5,14 @@ import com.checkping.api.auth.util.ResponseUtil;
 import com.checkping.common.enums.ErrorCode;
 import com.checkping.common.response.BaseResponse;
 import com.checkping.service.member.auth.CustomUserDetails;
+import com.checkping.service.member.auth.TokenBlacklistService;
 import com.checkping.service.member.util.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -22,98 +23,80 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.List;
 
+@RequiredArgsConstructor
 public class JWTFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final TokenBlacklistService tokenBlacklistService;
 
-    public JWTFilter(JwtUtil jwtUtil) {
-
-        this.jwtUtil = jwtUtil;
-    }
     // TODO 필터 거치지 않을 경로 설정
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String uri = request.getRequestURI();
 
-        // 기존 제외 경로
-        if (uri.startsWith("/h2-console") ||
+        return uri.startsWith("/h2-console") ||
                 uri.startsWith("/login") ||
                 uri.startsWith("/reissue") ||
-                uri.startsWith("/check")) {
-            return true;
-        }
-
-        // 스웨거 관련 경로 제외
-        if (uri.startsWith("/swagger-ui/") ||
+                uri.startsWith("/check")||
+                uri.startsWith("/swagger-ui/") ||
                 uri.equals("/swagger-ui") ||
-                uri.startsWith("/v3/api-docs")) {
-            return true;
-        }
-
-        return false;
+                uri.startsWith("/v3/api-docs");
     }
 
+    /**
+     * JWT 검증 및 인증 처리
+     */
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        // 쿠키에서 토큰 추출
-        Cookie[] cookies = request.getCookies();
+        // Access Token 쿠키에서 추출
+        String accessToken = JwtUtil.extractToken(request, "access");
 
-        // 쿠키가 없는 경우
-        if (cookies == null) {
-
-            BaseResponse<Void> errorResponse = BaseResponse.fail(ErrorCode.COOKIES_NOT_FOUND);
+        // 토큰이 없으면 401 응답
+        if (accessToken == null) {
+            BaseResponse errorResponse = BaseResponse.fail(ErrorCode.ACCESS_TOKEN_NOT_FOUND);
             ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-
             return;
         }
 
-        // access 토큰 추출
-        Cookie cookie = null;
-
-        for (Cookie c : cookies) {
-            if ("access".equals(c.getName())) {
-                cookie = c;
-                break;
-            }
-        }
-
-        String accessToken = cookie.getValue();
-
-
-        // 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
         try {
+            // 토큰 만료 여부 확인
             jwtUtil.isExpired(accessToken);
-        } catch (ExpiredJwtException e) {
 
+            // 3) Redis 블랙리스트 검증 (연결 여부 먼저 확인)
+            if (tokenBlacklistService.isRedisAvailable()) {
+                // 실제 Redis 연결이 된다면 블랙리스트 검사
+                if (tokenBlacklistService.isAccessTokenBlacklisted(accessToken)) {
+                    BaseResponse errorResponse = BaseResponse.fail(ErrorCode.BLACKLISTED_TOKEN);
+                    ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
+                    return;
+                }
+            } else {
+                // Redis 연결 불가능 시 로그만 남기고 스킵
+                // (또는 필요하다면 별도 처리)
+                System.out.println("[JWTFilter] Redis not available -> Skip blacklist check");
+            }
+
+            // 사용자 정보 추출
+            String name = jwtUtil.getName(accessToken);
+            String email = jwtUtil.getEmail(accessToken);
+            String role = jwtUtil.getRole(accessToken);
+            Long id = jwtUtil.getMemberId(accessToken);
+
+
+            CustomUserDetails customUserDetails = new CustomUserDetails(id, name, email, role, "PASSWORDFORTOKEN");
+            Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, List.of(new SimpleGrantedAuthority(customUserDetails.getRole())));
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        } catch (ExpiredJwtException e) {
             BaseResponse<Void> errorResponse = BaseResponse.fail(ErrorCode.EXPIRED_JWT_ACCESS_TOKEN);
             ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
-
+            return;
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "Invalid token");
             return;
         }
-
-        // 토큰이 access인지 확인 (발급시 페이로드에 명시)
-        String category = jwtUtil.getCategory(accessToken);
-
-        if (!category.equals("access")) {
-            String errorMessage = "invalid access token";
-            ResponseUtil.sendErrorResponse(response, HttpStatus.valueOf(HttpServletResponse.SC_UNAUTHORIZED), errorMessage);
-            return;
-        }
-
-        // username, role 값을 획득
-        String name = jwtUtil.getName(accessToken);
-        String email = jwtUtil.getEmail(accessToken);
-        String role = jwtUtil.getRole(accessToken);
-        Long id = jwtUtil.getMemberId(accessToken);
-        String password = "PASSWORDFORTOKEN";
-
-        CustomUserDetails customUserDetails = new CustomUserDetails(id, name, email, role, password);
-
-        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, List.of(new SimpleGrantedAuthority(customUserDetails.getRole())));
-        SecurityContextHolder.getContext().setAuthentication(authToken);
 
         filterChain.doFilter(request, response);
-
     }
 }

--- a/module-api/src/main/java/com/checkping/api/controller/member/auth/ReissueController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/member/auth/ReissueController.java
@@ -2,11 +2,13 @@ package com.checkping.api.controller.member.auth;
 
 import com.checkping.api.auth.util.CookieUtil;
 import com.checkping.common.response.BaseResponse;
+import com.checkping.exception.auth.BlacklistedTokenException;
 import com.checkping.service.member.auth.AuthTokens;
 import com.checkping.service.member.auth.ReissueService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -20,10 +22,18 @@ public class ReissueController implements ReissueApi {
     }
 
     @Override
+    @GetMapping("/reissue")
     public BaseResponse<?> reissue(HttpServletRequest request, HttpServletResponse response) {
 
-        // Get refresh token
+        // Refresh Token 추출
         String refresh = reissueService.validateAndExtractRefreshToken(request.getCookies());
+
+        // Refresh Token 블랙리스트 여부 확인
+        if (reissueService.isRefreshTokenBlacklisted(refresh)) {
+            throw new BlacklistedTokenException();
+        }
+
+        // Refresh Token 유효성 검사
         reissueService.checkTokenValidity(refresh);
 
         // Extract email and role
@@ -33,11 +43,11 @@ public class ReissueController implements ReissueApi {
         Long id = reissueService.getIdFromToken(refresh);
 
 
-        // Generate new tokens
+        // 새 토큰 발급
         String newAccess = reissueService.generateAccessToken(name, id, email, role);
         String newRefresh = reissueService.generateRefreshToken(name, id, email, role);
 
-        // Set response
+        // 쿠키에 토큰 저장
         response.addCookie(CookieUtil.createCookie("access", newAccess));
         response.addCookie(CookieUtil.createCookie("refresh", newRefresh));
 

--- a/module-api/src/main/resources/application-local.yaml
+++ b/module-api/src/main/resources/application-local.yaml
@@ -1,7 +1,12 @@
 spring:
   config:
+    import: application-s3.yaml, application-jwt.yaml
     activate:
       on-profile: local
+  data:
+    redis:
+      host: localhost
+      port: 6379
   h2:
     console:
       enabled: true

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
 

--- a/module-common/src/main/java/com/checkping/common/config/RedisConfig.java
+++ b/module-common/src/main/java/com/checkping/common/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.checkping.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost,redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
+++ b/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     INVALID_LOGIN_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일(로그인 전용 이메일) 또는 비밀번호를 잘못 입력했습니다." + "입력하신 내용을 다시 확인해주세요."),
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다. 이메일 또는 비밀번호를 다시 확인하세요."),
     LOGOUT_FAILURE(HttpStatus.UNAUTHORIZED, "로그인된 사용자가 아닙니다.\n 로그아웃에 실패하였습니다."),
+    BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "블랙리스트에 등록된 토큰입니다."),
     COOKIES_NOT_FOUND(HttpStatus.UNAUTHORIZED, "쿠키를 찾을 수 없습니다."),
 
     /*

--- a/module-service/build.gradle
+++ b/module-service/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     implementation project(':module-domain')

--- a/module-service/src/main/java/com/checkping/exception/auth/BlacklistedTokenException.java
+++ b/module-service/src/main/java/com/checkping/exception/auth/BlacklistedTokenException.java
@@ -1,0 +1,10 @@
+package com.checkping.exception.auth;
+
+import com.checkping.common.enums.ErrorCode;
+
+public class BlacklistedTokenException extends TokenException{
+
+    public BlacklistedTokenException() {
+        super("Blacklisted Token", ErrorCode.BLACKLISTED_TOKEN);
+    }
+}

--- a/module-service/src/main/java/com/checkping/exception/auth/BlacklistedTokenException.java
+++ b/module-service/src/main/java/com/checkping/exception/auth/BlacklistedTokenException.java
@@ -5,6 +5,6 @@ import com.checkping.common.enums.ErrorCode;
 public class BlacklistedTokenException extends TokenException{
 
     public BlacklistedTokenException() {
-        super("Blacklisted Token", ErrorCode.BLACKLISTED_TOKEN);
+        super("블랙리스트에 등록된 토큰입니다.", ErrorCode.BLACKLISTED_TOKEN);
     }
 }

--- a/module-service/src/main/java/com/checkping/service/member/auth/AuthService.java
+++ b/module-service/src/main/java/com/checkping/service/member/auth/AuthService.java
@@ -1,33 +1,27 @@
 package com.checkping.service.member.auth;
 
 import com.checkping.common.response.BaseResponse;
+import com.checkping.dto.member.response.MemberResponseDto;
 import com.checkping.exception.auth.InvalidTokenException;
 import com.checkping.exception.auth.LoginFailureException;
 import com.checkping.exception.auth.RefreshTokenNotFoundException;
 import com.checkping.service.member.util.CurrentMemberUtil;
 import com.checkping.service.member.util.JwtUtil;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
-import com.checkping.dto.member.response.MemberResponseDto;
 
 @Service
+@RequiredArgsConstructor
 public class AuthService {
 
     private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
     private final CurrentMemberUtil currentMemberUtil;
-
-    public AuthService(AuthenticationManager authenticationManager,
-                       JwtUtil jwtUtil,
-                       CurrentMemberUtil currentMemberUtil) {
-        this.authenticationManager = authenticationManager;
-        this.jwtUtil = jwtUtil;
-        this.currentMemberUtil = currentMemberUtil;
-    }
+    private final TokenBlacklistService tokenBlacklistService;
 
     public BaseResponse getCurrentMember() {
         return BaseResponse.success(MemberResponseDto.MeResponseDto.fromEntity(currentMemberUtil.getCurrentMember()));
@@ -70,30 +64,27 @@ public class AuthService {
      * - refresh 쿠키가 없거나 유효하지 않으면 예외 던지기
      */
     public void logout(HttpServletRequest request) {
-        // 1) 쿠키에서 refresh 추출
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) {
-            throw new LoginFailureException();
-        }
-
-        String refresh = null;
-        for (Cookie cookie : cookies) {
-            if ("refresh".equals(cookie.getName())) {
-                refresh = cookie.getValue();
-                break;
-            }
-        }
-
+        // Refresh Token 가져오기
+        String refresh = JwtUtil.extractToken(request, "refresh");
         if (refresh == null) {
             throw new RefreshTokenNotFoundException();
         }
 
-        // 2) refresh 토큰인지 확인
-        String category = jwtUtil.getCategory(refresh); // 파싱 실패 시 예외 발생 가능
-        if (!"refresh".equals(category)) {
+        // Access Token 가져오기
+        String accessToken = JwtUtil.extractToken(request, "access");
+
+        // 토큰 유효성 검증
+        if (!"refresh".equals(jwtUtil.getCategory(refresh))) {
             throw new InvalidTokenException();
         }
 
-        // TODO:  refresh 토큰을 블랙리스트 처리
+        // 블랙리스트 추가
+        if (accessToken != null) {
+            long accessTokenExpiration = jwtUtil.getExpiration(accessToken);
+            tokenBlacklistService.blacklistAccessToken(accessToken, accessTokenExpiration);
+        }
+
+        long refreshTokenExpiration = jwtUtil.getExpiration(refresh);
+        tokenBlacklistService.blacklistRefreshToken(refresh, refreshTokenExpiration);
     }
 }

--- a/module-service/src/main/java/com/checkping/service/member/auth/ReissueService.java
+++ b/module-service/src/main/java/com/checkping/service/member/auth/ReissueService.java
@@ -1,9 +1,6 @@
 package com.checkping.service.member.auth;
 
-import com.checkping.exception.auth.InvalidTokenException;
-import com.checkping.exception.auth.RefreshTokenCategoryException;
-import com.checkping.exception.auth.RefreshTokenExpiredException;
-import com.checkping.exception.auth.RefreshTokenNotFoundException;
+import com.checkping.exception.auth.*;
 import com.checkping.infra.repository.member.MemberRepository;
 import com.checkping.service.member.util.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -15,20 +12,24 @@ public class ReissueService {
 
     private final JwtUtil jwtUtil;
     private final MemberRepository memberRepository;
+    private final TokenBlacklistService tokenBlacklistService; // 추가
 
-    public ReissueService(JwtUtil jwtUtil, MemberRepository memberRepository) {
+    public ReissueService(JwtUtil jwtUtil, MemberRepository memberRepository, TokenBlacklistService tokenBlacklistService) {
         this.jwtUtil = jwtUtil;
         this.memberRepository = memberRepository;
+        this.tokenBlacklistService = tokenBlacklistService; // 추가
     }
 
+    /**
+     * 쿠키에서 Refresh Token 추출 및 검증
+     */
     public String validateAndExtractRefreshToken(Cookie[] cookies) {
-
         if (cookies == null || cookies.length == 0) {
             throw new RefreshTokenNotFoundException();
         }
 
         for (Cookie cookie : cookies) {
-            if (cookie.getName().equals("refresh")) {
+            if ("refresh".equals(cookie.getName())) {
                 return cookie.getValue();
             }
         }
@@ -36,13 +37,38 @@ public class ReissueService {
         throw new RefreshTokenNotFoundException();
     }
 
+    /**
+     * Refresh Token 블랙리스트 확인
+     */
+    public boolean isRefreshTokenBlacklisted(String refreshToken) {
+        // 1) Redis 연결 여부 확인
+        if (!tokenBlacklistService.isRedisAvailable()) {
+            // Redis가 연결 안 되어 있으면 블랙리스트 검증 스킵
+            return false;
+        }
+        // 2) 정상 연결 시 블랙리스트 검증
+        return tokenBlacklistService.isRefreshTokenBlacklisted(refreshToken);
+
+    }
+
+    /**
+     * Refresh Token 유효성 검증
+     */
     public void checkTokenValidity(String refreshToken) {
-
         try {
-            // 토큰이 만료되었는지 확인
-            jwtUtil.isExpired(refreshToken);
+            // 블랙리스트에 있는지 확인
+            if (tokenBlacklistService.isRedisAvailable()) {
+                if (tokenBlacklistService.isRefreshTokenBlacklisted(refreshToken)) { // 수정
+                    throw new BlacklistedTokenException();
+                }
+            }
 
-            // 토큰의 카테고리가 "refresh"인지 확인
+            // 토큰이 만료되었는지 확인
+            if (jwtUtil.isExpired(refreshToken)) {
+                throw new RefreshTokenExpiredException();
+            }
+
+            // 토큰의 카테고리 확인
             String category = jwtUtil.getCategory(refreshToken);
             if (!"refresh".equals(category)) {
                 throw new RefreshTokenCategoryException();
@@ -54,41 +80,52 @@ public class ReissueService {
                 throw new RefreshTokenNotFoundException();
             }
 
+        } catch (BlacklistedTokenException e) {
+            throw new InvalidTokenException(); // 블랙리스트에 있으면 InvalidTokenException으로 변환
         } catch (ExpiredJwtException e) {
             throw new RefreshTokenExpiredException();
         } catch (RefreshTokenCategoryException | RefreshTokenNotFoundException e) {
-            // 이미 위에 처리된 예외는 그대로 던짐
-            throw e;
+            throw e; // 이미 위에서 처리된 예외는 그대로 던짐
         } catch (Exception e) {
-            // 그 외에 예상하지 못한 예외를 InvalidTokenException으로 처리
-            throw new InvalidTokenException();
+            throw new InvalidTokenException(); // 그 외 예상하지 못한 예외 처리
         }
     }
 
-    public String getCategoryFromToken(String token) {
-        return jwtUtil.getCategory(token);
-    }
-
+    /**
+     * 토큰에서 사용자 이름 추출
+     */
     public String getNameFromToken(String token) {
         return jwtUtil.getName(token);
     }
 
+    /**
+     * 토큰에서 이메일 추출
+     */
     public String getEmailFromToken(String token) {
-        return jwtUtil.getEmail(token); // JwtUtil에서 호출
+        return jwtUtil.getEmail(token);
     }
 
+    /**
+     * 토큰에서 역할 추출
+     */
     public String getRoleFromToken(String token) {
-        return jwtUtil.getRole(token); // JwtUtil에서 호출
+        return jwtUtil.getRole(token);
     }
 
     public Long getIdFromToken(String token) {
         return jwtUtil.getMemberId(token); // JwtUtil에서 호출
     }
 
+    /**
+     * 새로운 Access Token 생성
+     */
     public String generateAccessToken(String name, Long id,  String email, String role) {
-        return jwtUtil.createJwt("access",id, name, email, role, 15);
+        return jwtUtil.createJwt("access",id, name, email, role, 1440);
     }
 
+    /**
+     * 새로운 Refresh Token 생성
+     */
     public String generateRefreshToken(String name, Long id, String email, String role) {
         return jwtUtil.createJwt("refresh", id, name, email, role, 1440);
     }

--- a/module-service/src/main/java/com/checkping/service/member/auth/TokenBlacklistService.java
+++ b/module-service/src/main/java/com/checkping/service/member/auth/TokenBlacklistService.java
@@ -1,0 +1,46 @@
+package com.checkping.service.member.auth;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class TokenBlacklistService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public TokenBlacklistService(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // Redis 연결 가능 여부 체크 메서드
+    public boolean isRedisAvailable() {
+        try {
+            String pong = redisTemplate.getConnectionFactory().getConnection().ping();
+            return "PONG".equalsIgnoreCase(pong);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // Access Token 블랙리스트 저장
+    public void blacklistAccessToken(String token, long expiration) {
+        redisTemplate.opsForValue().set("access_" + token, "blacklisted", expiration, TimeUnit.MILLISECONDS);
+    }
+
+    // Refresh Token 블랙리스트 저장
+    public void blacklistRefreshToken(String token, long expiration) {
+        redisTemplate.opsForValue().set("refresh_" + token, "blacklisted", expiration, TimeUnit.MILLISECONDS);
+    }
+
+    // Access Token 블랙리스트 확인
+    public boolean isAccessTokenBlacklisted(String token) {
+        return redisTemplate.hasKey("access_" + token);
+    }
+
+    // Refresh Token 블랙리스트 확인
+    public boolean isRefreshTokenBlacklisted(String token) {
+        return redisTemplate.hasKey("refresh_" + token);
+    }
+}

--- a/module-service/src/main/java/com/checkping/service/member/util/JwtUtil.java
+++ b/module-service/src/main/java/com/checkping/service/member/util/JwtUtil.java
@@ -1,8 +1,11 @@
 package com.checkping.service.member.util;
 
+import com.checkping.service.member.auth.TokenBlacklistService;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -13,37 +16,119 @@ import java.util.Date;
 @Component
 public class JwtUtil {
 
-    private Key key;
+    private final Key key;
+    private final TokenBlacklistService tokenBlacklistService;
 
-    public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
-
+    public JwtUtil(@Value("${spring.jwt.secret}") String secret, TokenBlacklistService tokenBlacklistService) {
         byte[] byteSecretKey = Decoders.BASE64.decode(secret);
-        key = Keys.hmacShaKeyFor(byteSecretKey);
+        this.key = Keys.hmacShaKeyFor(byteSecretKey);
+        this.tokenBlacklistService = tokenBlacklistService;
     }
 
+    /**
+     * JWT에서 카테고리(category) 가져오기
+     */
     public String getCategory(String token) {
-
-        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().get("category", String.class);
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("category", String.class);
     }
 
+    /**
+     * JWT에서 이메일(email) 가져오기
+     */
     public String getEmail(String token) {
-
-        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().get("email", String.class);
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("email", String.class);
     }
 
+    /**
+     * JWT에서 역할(role) 가져오기
+     */
     public String getRole(String token) {
-
-        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().get("role", String.class);
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("role", String.class);
     }
 
+    /**
+     * JWT에서 사용자 이름(name) 가져오기
+     */
     public String getName(String token) {
-
-        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().get("name", String.class);
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("name", String.class);
     }
 
-    public Boolean isExpired(String token) {
+    /**
+     * 토큰이 만료되었는지 확인
+     */
+    public boolean isExpired(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getExpiration()
+                    .before(new Date());
+        } catch (Exception e) {
+            return true; // 토큰 파싱에 실패하면 만료된 것으로 간주
+        }
+    }
 
-        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getExpiration().before(new Date());
+    /**
+     * Access Token 블랙리스트 확인
+     */
+    public boolean isAccessTokenBlacklisted(String token) {
+        return tokenBlacklistService.isAccessTokenBlacklisted("access_" + token);
+    }
+
+    /**
+     * Refresh Token 블랙리스트 확인
+     */
+    public boolean isRefreshTokenBlacklisted(String token) {
+        return tokenBlacklistService.isRefreshTokenBlacklisted("refresh_" + token);
+    }
+
+    /**
+     * 쿠키에서 특정 토큰을 추출
+     */
+    public static String extractToken(HttpServletRequest request, String tokenName) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (tokenName.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * JWT 만료 시간 가져오기
+     */
+    public long getExpiration(String token) {
+        Date expiration = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+        return expiration.getTime() - System.currentTimeMillis();
     }
 
     public Long getMemberId(String token) {
@@ -51,17 +136,17 @@ public class JwtUtil {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().get("memberId", Long.class);
     }
 
-    public String createJwt(String category, Long memberId ,String name, String email, String role, int expiredMin) {
-
+    /**
+     * JWT 생성 (Access/Refresh 토큰)
+     */
+    public String createJwt(String category, Long memberId, String name, String email, String role, int expiredMin) {
         return Jwts.builder()
                 .claim("category", category)
                 .claim("memberId", memberId)
                 .claim("name", name)
                 .claim("email", email)
                 .claim("role", role)
-                //토큰 발급시간 설정- 현재시간
                 .setIssuedAt(Date.from(ZonedDateTime.now().toInstant()))
-                //토큰 만료시간 설정- 현재시간 + expiredMin
                 .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(expiredMin).toInstant()))
                 .signWith(key)
                 .compact();


### PR DESCRIPTION
# 🚀 Pull Request

Redis와 JWT 필터를 활용하여 토큰 블랙리스트 기능을 구현

## #️⃣ 연관된 이슈

#327

## 📋 작업 내용

Redis 설정
	•	Redis 의존성 추가
	•	LettuceConnectionFactory를 이용한 RedisConnectionFactory 빈 등록
	•	RedisTemplate을 설정하여 키와 값을 StringRedisSerializer로 직렬화

블랙리스트 토큰 서비스
	•	Access Token과 Refresh Token을 Redis로 블랙리스트 처리
	•	블랙리스트 등록 메서드 추가
	•	블랙리스트 여부 확인 메서드 추가
	•	만료 시간 설정 및 키 관리

JWT 유틸리티 수정
	•	블랙리스트 여부 확인 메서드 추가
	•	기존 JWT 파싱 로직에 블랙리스트 처리 로직 통합

로그아웃 기능
	•	로그아웃 시 Access Token과 Refresh Token을 블랙리스트에 추가
	•	유효하지 않은 Refresh Token 요청에 대한 예외 처리

토큰 재발급
	•	Refresh Token 재발급 시 블랙리스트 여부 검증
	•	블랙리스트된 토큰 요청 시 BlacklistedTokenException 발생
	•	새로 발급된 Access Token 및 Refresh Token을 쿠키에 저장

JWT 필터 수정
	•	JWTFilter에 블랙리스트 검증 로직 추가
	•	블랙리스트된 토큰 감지 시 401 Unauthorized 응답 반환
	•	CustomSecurityConfig에서 TokenBlacklistService를 JWTFilter에 주입

기타 수정
	•	JWTFilter에서 쿠키가 없거나 만료된 경우 응답값 수정
	•	ErrorCode에 COOKIES_NOT_FOUND 에러코드 추가
