### PR TITLE
Feature/363 관리자 회원 상태 변경 및 차단 기능 구현, 권한 없는 요청 응답 메시지 적용

### DIFF
--- a/module-api/src/main/java/com/checkping/api/auth/config/CustomSecurityConfig.java
+++ b/module-api/src/main/java/com/checkping/api/auth/config/CustomSecurityConfig.java
@@ -1,6 +1,8 @@
 package com.checkping.api.auth.config;
 
 import com.checkping.api.auth.filter.JWTFilter;
+import com.checkping.api.exceptionhandler.CustomAccessDeniedHandler;
+import com.checkping.service.member.MemberService;
 import com.checkping.service.member.auth.TokenBlacklistService;
 import com.checkping.service.member.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,8 @@ public class CustomSecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtUtil jwtUtil;
     private final TokenBlacklistService tokenBlacklistService;
+    private final MemberService memberService;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     //AuthenticationManager Bean 등록
     @Bean
@@ -70,7 +74,9 @@ public class CustomSecurityConfig {
                 .requestMatchers("/v3/api-docs/**").permitAll()
                 .anyRequest().authenticated());
 
-        http.addFilterBefore(new JWTFilter(jwtUtil,tokenBlacklistService), UsernamePasswordAuthenticationFilter.class);
+        http.exceptionHandling((exception) -> exception.accessDeniedHandler(customAccessDeniedHandler));
+
+        http.addFilterBefore(new JWTFilter(jwtUtil,tokenBlacklistService,memberService), UsernamePasswordAuthenticationFilter.class);
 
         //세션 설정
         http.sessionManagement(

--- a/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
@@ -1,9 +1,9 @@
 package com.checkping.api.auth.filter;
 
-
 import com.checkping.api.auth.util.ResponseUtil;
 import com.checkping.common.enums.ErrorCode;
 import com.checkping.common.response.BaseResponse;
+import com.checkping.service.member.MemberService;
 import com.checkping.service.member.auth.CustomUserDetails;
 import com.checkping.service.member.auth.TokenBlacklistService;
 import com.checkping.service.member.util.JwtUtil;
@@ -28,6 +28,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
     private final TokenBlacklistService tokenBlacklistService;
+    private final MemberService memberService;
 
     // TODO 필터 거치지 않을 경로 설정
     @Override
@@ -72,7 +73,6 @@ public class JWTFilter extends OncePerRequestFilter {
                 }
             } else {
                 // Redis 연결 불가능 시 로그만 남기고 스킵
-                // (또는 필요하다면 별도 처리)
                 System.out.println("[JWTFilter] Redis not available -> Skip blacklist check");
             }
 
@@ -82,6 +82,12 @@ public class JWTFilter extends OncePerRequestFilter {
             String role = jwtUtil.getRole(accessToken);
             Long id = jwtUtil.getMemberId(accessToken);
 
+            String memberStatus = memberService.getMemberStatus(id);
+            if (!memberStatus.equals("ACTIVE")) {
+                BaseResponse errorResponse = BaseResponse.fail(ErrorCode.INACTIVE_OR_DELETED_MEMBER);
+                ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
+                return;
+            }
 
             CustomUserDetails customUserDetails = new CustomUserDetails(id, name, email, role, "PASSWORDFORTOKEN");
             Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, List.of(new SimpleGrantedAuthority(customUserDetails.getRole())));

--- a/module-api/src/main/java/com/checkping/api/controller/member/AdminMemberApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/member/AdminMemberApi.java
@@ -70,4 +70,9 @@ public interface AdminMemberApi {
     BaseResponse<String> activateMember(
         @Schema(description = "회원 ID", example = "1")
         @Parameter(description = "회원 ID", required = true) Long memberId);
+
+    @Operation(summary = "회원 비활성화 처리", description = "활성화된 회원을 비활성화 처리하는 기능입니다.")
+    BaseResponse<String> deactivateMember(
+        @Schema(description = "회원 ID", example = "1")
+        @Parameter(description = "회원 ID", required = true) Long memberId);
 }

--- a/module-api/src/main/java/com/checkping/api/controller/member/AdminMemberApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/member/AdminMemberApi.java
@@ -6,14 +6,12 @@ import com.checkping.dto.member.request.MemberRegisterDto;
 import com.checkping.dto.member.request.MemberUpdateDto;
 import com.checkping.dto.member.response.MemberListResponseDto;
 import com.checkping.dto.member.response.MemberResponseDto;
-import com.checkping.dto.member.response.MemberSignatureResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
-import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "회원 관리 API(AdminMemberApi)", description = "회원 관리 API입니다.")
 public interface AdminMemberApi {
@@ -58,7 +56,7 @@ public interface AdminMemberApi {
         @Schema(description = "회원 ID", example = "1")
         @Parameter(description = "회원 ID", required = true) Long memberId,
         //이유 예외처리 예시
-        @Schema(description = "탈퇴 사유", example = "{reason : '퇴사로 인한 탈퇴'}")
+        @Schema(description = "탈퇴 사유", example = "퇴사로 인한 탈퇴")
         @Parameter(description = "탈퇴 사유", required = true) String reason);
 
     @Operation(summary = "소속 업체별 회원 조회", description = "특정 소속 업체의 회원 목록을 조회하는 기능입니다.")
@@ -67,4 +65,9 @@ public interface AdminMemberApi {
         @Parameter(description = "소속 업체 ID", required = true) Long organizationId,
         @Parameter(description = "페이지 번호 (1부터 시작)", example = "1", required = true) int page,
         @Parameter(description = "페이지 크기", example = "10", required = true) int size);
+
+    @Operation(summary = "회원 활성화 처리", description = "비활성화되거나 삭제된 회원을 활성화 처리하는 기능입니다.")
+    BaseResponse<String> activateMember(
+        @Schema(description = "회원 ID", example = "1")
+        @Parameter(description = "회원 ID", required = true) Long memberId);
 }

--- a/module-api/src/main/java/com/checkping/api/controller/member/AdminMemberController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/member/AdminMemberController.java
@@ -1,25 +1,14 @@
 package com.checkping.api.controller.member;
 
 import com.checkping.common.response.BaseResponse;
-import com.checkping.common.utils.FileResponse;
 import com.checkping.dto.member.request.ChangePasswordDto;
 import com.checkping.dto.member.request.MemberRegisterDto;
 import com.checkping.dto.member.request.MemberUpdateDto;
 import com.checkping.dto.member.response.MemberListResponseDto;
 import com.checkping.dto.member.response.MemberResponseDto;
-import com.checkping.dto.member.response.MemberSignatureResponseDto;
-import com.checkping.service.file.FileService;
 import com.checkping.service.member.MemberService;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "어드민 회원 관리 API(AdminMemberApi)", description = "어드민 권한으로 회원을 관리할 수 있도록 하는 API입니다.")
 @RestController
@@ -105,5 +94,12 @@ public class AdminMemberController implements AdminMemberApi {
             @RequestParam(defaultValue = "10") int pageSize) {
         MemberListResponseDto response = memberService.getMembersByOrganizationId(organizationId, currentPage-1, pageSize);
         return BaseResponse.success(response);
+    }
+
+    //회원 활성화
+    @PostMapping("/activate")
+    public BaseResponse<String> activateMember(@RequestParam Long memberId) {
+        memberService.activateMember(memberId);
+        return BaseResponse.success("회원이 성공적으로 활성화되었습니다.");
     }
 }

--- a/module-api/src/main/java/com/checkping/api/controller/member/AdminMemberController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/member/AdminMemberController.java
@@ -97,9 +97,18 @@ public class AdminMemberController implements AdminMemberApi {
     }
 
     //회원 활성화
+    @Override
     @PostMapping("/activate")
     public BaseResponse<String> activateMember(@RequestParam Long memberId) {
         memberService.activateMember(memberId);
         return BaseResponse.success("회원이 성공적으로 활성화되었습니다.");
+    }
+
+    //회원 비활성화
+    @Override
+    @PostMapping("/deactivate")
+    public BaseResponse<String> deactivateMember(@RequestParam Long memberId) {
+        memberService.deactivateMember(memberId);
+        return BaseResponse.success("회원이 성공적으로 비활성화되었습니다.");
     }
 }

--- a/module-api/src/main/java/com/checkping/api/exceptionhandler/CustomAccessDeniedHandler.java
+++ b/module-api/src/main/java/com/checkping/api/exceptionhandler/CustomAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package com.checkping.api.exceptionhandler;
+
+import com.checkping.common.response.BaseResponse;
+import com.checkping.common.enums.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setCharacterEncoding("UTF-8");
+
+        // BaseResponse 사용
+        BaseResponse<?> errorResponse = BaseResponse.fail(ErrorCode.FORBIDDEN);
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
+++ b/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
@@ -33,7 +33,7 @@ public enum ErrorCode {
     /*
         403 Forbidden
     */
-    FORBIDDEN(HttpStatus.FORBIDDEN, "요청 권한이 부족합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     /*
         404 Not Found
@@ -51,6 +51,7 @@ public enum ErrorCode {
     INSUFFICIENT_PERMISSIONS(HttpStatus.CONFLICT, "권한이 부족합니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     INACTIVE_MEMBER(HttpStatus.CONFLICT, "비활성화된 회원입니다."),
+    INACTIVE_OR_DELETED_MEMBER(HttpStatus.CONFLICT, "비활성화 또는 삭제된 회원입니다."),
 
     /*
         500 Internal Server Error

--- a/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
+++ b/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     ORGANIZATION_NOT_FOUND(HttpStatus.NOT_FOUND, "업체를 찾을 수 없습니다."),
+    DELETED_MEMBER(HttpStatus.NOT_FOUND, "삭제된 회원입니다."),
 
     /*
         409 Conflict
@@ -49,6 +50,7 @@ public enum ErrorCode {
     ALREADY_APPLIED(HttpStatus.CONFLICT, "이미 적용된 상태입니다."),
     INSUFFICIENT_PERMISSIONS(HttpStatus.CONFLICT, "권한이 부족합니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    INACTIVE_MEMBER(HttpStatus.CONFLICT, "비활성화된 회원입니다."),
 
     /*
         500 Internal Server Error

--- a/module-domain/src/main/java/com/checkping/domain/member/Member.java
+++ b/module-domain/src/main/java/com/checkping/domain/member/Member.java
@@ -111,7 +111,7 @@ public class Member extends BaseEntity {
     }
 
     public enum Status {
-        ACTIVE, INACTIVE
+        ACTIVE, INACTIVE, DELETED
     }
 
     // 비밀번호 변경

--- a/module-domain/src/main/java/com/checkping/domain/member/Member.java
+++ b/module-domain/src/main/java/com/checkping/domain/member/Member.java
@@ -137,7 +137,8 @@ public class Member extends BaseEntity {
     }
 
     // 회원 비활성화 처리
-    public void inactiveAccount() {
+    public void deactivateAccount() {
+        this.remark = "회원 비활성화됨 : " + LocalDate.now();
         this.status = Status.INACTIVE;
     }
 
@@ -149,8 +150,8 @@ public class Member extends BaseEntity {
     }
 
     //회원 활성화
-    public void activeAccount() {
-        this.reasonForDeleteAccount = "회원 재활성화 : " + LocalDate.now();
+    public void activateAccount() {
+        this.reasonForDeleteAccount = "회원 재활성화됨 : " + LocalDate.now();
         this.status = Status.ACTIVE;
     }
 

--- a/module-domain/src/main/java/com/checkping/domain/member/Member.java
+++ b/module-domain/src/main/java/com/checkping/domain/member/Member.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -135,15 +136,30 @@ public class Member extends BaseEntity {
         this.loginFailCount = 0;
     }
 
+    // 회원 비활성화 처리
+    public void inactiveAccount() {
+        this.status = Status.INACTIVE;
+    }
+
     // 회원 삭제(탈퇴) 처리
     public void deleteAccount(String reason) {
         this.deleteAccountAt = LocalDateTime.now();
         this.reasonForDeleteAccount = reason;
-        this.status = Status.INACTIVE;
+        this.status = Status.DELETED;
+    }
+
+    //회원 활성화
+    public void activeAccount() {
+        this.reasonForDeleteAccount = "회원 재활성화 : " + LocalDate.now();
+        this.status = Status.ACTIVE;
     }
 
     public boolean isActive() {
         return this.status == Status.ACTIVE;
+    }
+
+    public boolean isDeleted() {
+        return this.status == Status.DELETED;
     }
 
     /** 회원 정보를 DTO 기반으로 업데이트*/

--- a/module-service/src/main/java/com/checkping/dto/member/request/LoginRequestDto.java
+++ b/module-service/src/main/java/com/checkping/dto/member/request/LoginRequestDto.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Setter
 public class LoginRequestDto {
 
-    @Schema(description = "이메일", example = "admin@Test.com")
+    @Schema(description = "이메일", example = "test@test.com")
     private String email;
     @Schema(description = "비밀번호", example = "1111")
     private String password;

--- a/module-service/src/main/java/com/checkping/dto/member/request/MemberRegisterDto.java
+++ b/module-service/src/main/java/com/checkping/dto/member/request/MemberRegisterDto.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class MemberRegisterDto {
 
-    @Schema(description = "조직 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    @Schema(description = "조직 ID", example = "1")
     private Long organizationId;
     @Schema(description = "이메일", example = "example@example.com")
     private String email;

--- a/module-service/src/main/java/com/checkping/dto/member/request/MemberUpdateDto.java
+++ b/module-service/src/main/java/com/checkping/dto/member/request/MemberUpdateDto.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class MemberUpdateDto {
-    @Schema(description = "이름", example = "Optimus Prime")
+    @Schema(description = "이름", example = "홍길동")
     private String name;
     @Schema(description = "전화번호", example = "010-1234-5678")
     private String phoneNum;
@@ -18,9 +18,9 @@ public class MemberUpdateDto {
     private String jobRole;
     @Schema(description = "직책", example = "팀장")
     private String jobTitle;
-    @Schema(description = "소개", example = "안녕하세요. 저는 옵티머스프라임입니다.")
+    @Schema(description = "소개", example = "홍길동입니다")
     private String introduction;
-    @Schema(description = "비고", example = "곧 퇴사함")
+    @Schema(description = "비고", example = "비고입니다")
     private String remark;
 
     public static Member toEntity(Member member, MemberUpdateDto dto) {

--- a/module-service/src/main/java/com/checkping/dto/member/response/MemberResponseDto.java
+++ b/module-service/src/main/java/com/checkping/dto/member/response/MemberResponseDto.java
@@ -1,5 +1,6 @@
 package com.checkping.dto.member.response;
 
+import com.checkping.common.utils.DateTimeUtils;
 import com.checkping.domain.member.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -21,7 +22,7 @@ public class MemberResponseDto {
     private Member.Status status;
     @Schema(description = "이메일", example = "example@example.com")
     private String email;
-    @Schema(description = "이름", example = "Optimus Prime")
+    @Schema(description = "이름", example = "홍길동")
     private String name;
     @Schema(description = "전화번호", example = "010-1234-5678")
     private String phoneNum;
@@ -31,9 +32,9 @@ public class MemberResponseDto {
     private String jobTitle;
     @Schema(description = "등록 일시", example = "2021-07-01 12:00:00")
     private String regAt;
-    @Schema(description = "소개", example = "안녕하세요. 저는 옵티머스프라임입니다.")
+    @Schema(description = "소개", example = "안녕하세요.")
     private String introduction;
-    @Schema(description = "비고", example = "곧 퇴사함")
+    @Schema(description = "비고", example = "비고입니다.")
     private String remark;
 
     public static MemberResponseDto fromEntity(Member member) {
@@ -49,7 +50,7 @@ public class MemberResponseDto {
                 .jobRole(member.getJobRole())
                 .jobTitle(member.getJobTitle())
                 .jobRole(member.getJobRole())
-                .regAt(member.getRegAt().toString())
+                .regAt(DateTimeUtils.format(member.getRegAt()))
                 .introduction(member.getIntroduction())
                 .remark(member.getRemark())
                 .build();

--- a/module-service/src/main/java/com/checkping/service/member/MemberService.java
+++ b/module-service/src/main/java/com/checkping/service/member/MemberService.java
@@ -170,7 +170,7 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(
                 () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
-        if (!member.isActive()) {
+        if (member.isDeleted()) {
             throw new BaseException("이미 삭제된 회원입니다.", ErrorCode.ALREADY_APPLIED);
         }
         // 회원 삭제 처리
@@ -235,5 +235,18 @@ public class MemberService {
         Member member = currentMemberUtil.getCurrentMember();
 
         return MemberSignatureExistResponseDto.toDto(member);
+    }
+
+    //회원 활성화
+    public void activateMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(
+                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
+
+        if(member.isActive()){
+            throw new BaseException("이미 활성화된 회원입니다.", ErrorCode.ALREADY_APPLIED);
+        }
+        member.activeAccount();
+        memberRepository.save(member);
     }
 }

--- a/module-service/src/main/java/com/checkping/service/member/MemberService.java
+++ b/module-service/src/main/java/com/checkping/service/member/MemberService.java
@@ -246,7 +246,28 @@ public class MemberService {
         if(member.isActive()){
             throw new BaseException("이미 활성화된 회원입니다.", ErrorCode.ALREADY_APPLIED);
         }
-        member.activeAccount();
+        member.activateAccount();
+        memberRepository.save(member);
+    }
+
+    /*
+    * 회원 비활성화
+    * 관리자가 회원을 비활성화 처리합니다. - inactiveAccount
+    * */
+
+    public void deactivateMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(
+                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
+
+        if(member.isDeleted()){
+            throw new BaseException("삭제된 회원입니다.", ErrorCode.ALREADY_APPLIED);
+        }
+
+        if(!member.isActive()){
+            throw new BaseException("이미 비활성화된 회원입니다.", ErrorCode.ALREADY_APPLIED);
+        }
+        member.deactivateAccount();
         memberRepository.save(member);
     }
 }

--- a/module-service/src/main/java/com/checkping/service/member/MemberService.java
+++ b/module-service/src/main/java/com/checkping/service/member/MemberService.java
@@ -42,7 +42,7 @@ public class MemberService {
         this.currentMemberUtil = currentMemberUtil;
     }
 
-    // 이메일로 회원 조회
+    // 아이디로 회원 조회
     public MemberResponseDto getMemberById(Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(
@@ -269,5 +269,12 @@ public class MemberService {
         }
         member.deactivateAccount();
         memberRepository.save(member);
+    }
+
+    public String getMemberStatus(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(
+                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
+        return member.getStatus().name();
     }
 }

--- a/module-service/src/main/java/com/checkping/service/member/auth/CustomUserDetailsService.java
+++ b/module-service/src/main/java/com/checkping/service/member/auth/CustomUserDetailsService.java
@@ -28,7 +28,11 @@ public class CustomUserDetailsService implements UserDetailsService {
         Member member = result.orElseThrow(() -> new UsernameNotFoundException(email));
 
         if (member.getStatus() == Member.Status.INACTIVE) {
-            throw new InactiveMemberException("삭제된 회원입니다", ErrorCode.USER_NOT_FOUND);
+            throw new InactiveMemberException("비활성화된 회원입니다", ErrorCode.INACTIVE_MEMBER);
+        }
+
+        if (member.getStatus() == Member.Status.DELETED) {
+            throw new InactiveMemberException("삭제된 회원입니다", ErrorCode.DELETED_MEMBER);
         }
 
         if (member != null) {


### PR DESCRIPTION
# 🚀 Pull Request
 관리자 회원 상태 변경 및 차단 기능 구현, 권한 없는 요청 응답 메시지 적용

## #️⃣ 연관된 이슈

#363 

## 📋 작업 내용

- 회원 status 목록에 DELETED 추가
- Member.java : 멤버 상태 (Status) 비활성화, 삭제 상태로 바꿀 수 있도록 변경
- MemberService.java : 삭제되거나 비활성화된 회원 재 활성화 기능 추가
- AdminMemberController.java : 회원 재활성화 기능 추가
- CustomUserDetailsService.java : 삭제되거나 비활성화된 회원 로그인 못하도록 조건 추가
- Dto 파일 스웨거 예시 변경
- MemberService.getMemberStatus : 회원의 Id를 받아 상태를 리턴하는 메서드 추가
- JWTFilter.doFilterInternal : 요청 엑세스 토큰의 회원 Id 를 받아 DB에 해당 회원 상태조회 후 활성화된 회원인 지 확인 하는 조건 추가
- ErrorCode.INACTIVE_OR_DELETED_MEMBER : 에러코드 추가
- CustomAccessDeniedHandler에서 BaseResponse를 사용하여 응답 메시지 통일
- ErrorCode Enum에 FORBIDDEN(403) 메시지 수정
- Unauthorized 요청 시 클라이언트가 일관된 형식으로 응답을 처리할 수 있도록 개선
