### PR TITLE
Feature/402 feature 결재 게시글 개수 조회 기능

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/approval/ApprovalApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/approval/ApprovalApi.java
@@ -2,6 +2,7 @@ package com.checkping.api.controller.approval;
 
 import com.checkping.common.response.BaseResponse;
 import com.checkping.dto.approval.ApprovalConfirm;
+import com.checkping.dto.approval.ApprovalCount;
 import com.checkping.dto.approval.ApprovalDelete;
 import com.checkping.dto.approval.ApprovalGet;
 import com.checkping.dto.approval.ApprovalRegister;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
+import java.util.List;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -71,4 +73,8 @@ public interface ApprovalApi {
         @Parameter(description = "프로젝트 ID") @PathVariable Long projectId,
         @Parameter(description = "결재 ID") @PathVariable Long approvalId,
         @Parameter(description = "결재 승인 정보") @RequestBody ApprovalConfirm.Request request);
+
+    @Operation(summary="프로젝트 진행 단계 별 결재 글 개수 조회", description="프로젝트 진행 단계 별 결재 글 개수를 조회하는 기능입니다.")
+    BaseResponse<List<ApprovalCount.Response>> countByProgressStep(
+        @Parameter(description="프로젝트 ID") @PathVariable Long projectId);
 }

--- a/module-api/src/main/java/com/checkping/api/controller/approval/ApprovalController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/approval/ApprovalController.java
@@ -2,6 +2,7 @@ package com.checkping.api.controller.approval;
 
 import com.checkping.common.response.BaseResponse;
 import com.checkping.dto.approval.ApprovalConfirm;
+import com.checkping.dto.approval.ApprovalCount;
 import com.checkping.dto.approval.ApprovalDelete;
 import com.checkping.dto.approval.ApprovalGet;
 import com.checkping.dto.approval.ApprovalRegister;
@@ -14,6 +15,7 @@ import com.checkping.dto.approval.comment.ApprovalCommentRegister;
 import com.checkping.dto.approval.comment.ApprovalReCommentRegister;
 import com.checkping.service.approval.ApprovalService;
 import jakarta.validation.constraints.Min;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
@@ -125,6 +127,15 @@ public class ApprovalController implements ApprovalApi {
 
         // Confirm Approval
         ApprovalConfirm.Response response = approvalService.confirm(projectId, approvalId, request);
+
+        return BaseResponse.success(response);
+    }
+
+    @GetMapping("/counts")
+    @Override
+    public BaseResponse<List<ApprovalCount.Response>> countByProgressStep(@PathVariable Long projectId) {
+
+        List<ApprovalCount.Response> response = approvalService.count(projectId);
 
         return BaseResponse.success(response);
     }

--- a/module-api/src/main/java/com/checkping/api/controller/approval/ApprovalController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/approval/ApprovalController.java
@@ -6,8 +6,6 @@ import com.checkping.dto.approval.ApprovalCount;
 import com.checkping.dto.approval.ApprovalDelete;
 import com.checkping.dto.approval.ApprovalGet;
 import com.checkping.dto.approval.ApprovalRegister;
-import com.checkping.dto.approval.ApprovalRegister.Request;
-import com.checkping.dto.approval.ApprovalRegister.Response;
 import com.checkping.dto.approval.ApprovalSearch;
 import com.checkping.dto.approval.ApprovalSearchCondition;
 import com.checkping.dto.approval.ApprovalUpdate;
@@ -135,7 +133,7 @@ public class ApprovalController implements ApprovalApi {
     @Override
     public BaseResponse<List<ApprovalCount.Response>> countByProgressStep(@PathVariable Long projectId) {
 
-        List<ApprovalCount.Response> response = approvalService.count(projectId);
+        List<ApprovalCount.Response> response = approvalService.countByProgressStep(projectId);
 
         return BaseResponse.success(response);
     }

--- a/module-domain/src/main/java/com/checkping/info/approval/ApprovalCountProjection.java
+++ b/module-domain/src/main/java/com/checkping/info/approval/ApprovalCountProjection.java
@@ -1,0 +1,22 @@
+package com.checkping.info.approval;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class ApprovalCountProjection {
+    private Long id;
+    private String title;
+    private String value;
+    private Long count;
+    private String status;
+
+    @QueryProjection
+    public ApprovalCountProjection(Long id, String title, String value, Long count, String status) {
+        this.id = id;
+        this.title = title;
+        this.value = value;
+        this.count = count;
+        this.status = status;
+    }
+}

--- a/module-domain/src/main/java/com/checkping/info/approval/ApprovalCountProjection.java
+++ b/module-domain/src/main/java/com/checkping/info/approval/ApprovalCountProjection.java
@@ -10,13 +10,15 @@ public class ApprovalCountProjection {
     private String value;
     private Long count;
     private String status;
+    private Integer stepOrder;
 
     @QueryProjection
-    public ApprovalCountProjection(Long id, String title, String value, Long count, String status) {
+    public ApprovalCountProjection(Long id, String title, String value, Long count, String status, Integer stepOrder) {
         this.id = id;
         this.title = title;
         this.value = value;
         this.count = count;
         this.status = status;
+        this.stepOrder = stepOrder;
     }
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepository.java
@@ -1,0 +1,6 @@
+package com.checkping.infra.repository.approval;
+
+public interface ApprovalCustomRepository {
+
+    Long countByProgressStep(Long projectId, Long progressStepId);
+}

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepository.java
@@ -1,6 +1,9 @@
 package com.checkping.infra.repository.approval;
 
+import com.checkping.info.approval.ApprovalCountProjection;
+import java.util.List;
+
 public interface ApprovalCustomRepository {
 
-    Long countByProgressStep(Long projectId, Long progressStepId);
+    List<ApprovalCountProjection> countByProgressStep(Long projectId);
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepositoryImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepositoryImpl.java
@@ -1,9 +1,14 @@
 package com.checkping.infra.repository.approval;
 
 import static com.checkping.domain.approval.QApproval.approval;
+import static com.checkping.domain.project.QProgressStep.progressStep;
 
 import com.checkping.domain.approval.Approval;
+import com.checkping.info.approval.ApprovalCountProjection;
+import com.checkping.info.approval.QApprovalCountProjection;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,15 +21,27 @@ public class ApprovalCustomRepositoryImpl implements ApprovalCustomRepository {
     }
 
     @Override
-    public Long countByProgressStep(Long projectId, Long progressStepId) {
-        return queryFactory
-            .select(approval.count())
-            .from(approval)
-            .where(
-                approval.project.id.eq(projectId), // 프로젝트 ID
-                approval.progressStep.id.eq(progressStepId), // 진행상태 ID
-                approval.deleteYn.eq(Approval.DeleteStatus.N) // 삭제 여부
+    public List<ApprovalCountProjection> countByProgressStep(Long projectId) {
+
+        JPAQuery<ApprovalCountProjection> query = queryFactory
+            .select(new QApprovalCountProjection(
+                progressStep.id,                     // ✅ 진행 단계 ID
+                progressStep.name,                   // ✅ 진행 단계 이름
+                progressStep.description,            // ✅ 진행 단계 설명
+                approval.count().coalesce(0L),       // ✅ 개수가 없으면 0 반환
+                progressStep.status.stringValue() // ✅ 진행 단계 상태
+            ))
+            .from(progressStep) // ✅ 진행 단계 테이블을 기준으로 조회
+            .leftJoin(approval).on(
+                approval.progressStep.id.eq(progressStep.id)
+                    .and(approval.project.id.eq(projectId)) // 특정 프로젝트 내에서만 조회
+                    .and(approval.deleteYn.eq(Approval.DeleteStatus.N)) // 삭제되지 않은 데이터만 포함
             )
-            .fetchOne();
+            .where(
+                progressStep.projectId.eq(projectId) // ✅ 프로젝트 ID 조건
+            )
+            .groupBy(progressStep.id); // ✅ 진행 단계 ID로 그룹화
+
+        return query.fetch();
     }
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepositoryImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepositoryImpl.java
@@ -29,7 +29,8 @@ public class ApprovalCustomRepositoryImpl implements ApprovalCustomRepository {
                 progressStep.name,                   // ✅ 진행 단계 이름
                 progressStep.description,            // ✅ 진행 단계 설명
                 approval.count().coalesce(0L),       // ✅ 개수가 없으면 0 반환
-                progressStep.status.stringValue() // ✅ 진행 단계 상태
+                progressStep.status.stringValue(), // ✅ 진행 단계 상태
+                progressStep.stepOrder                // ✅ 진행 단계 순서
             ))
             .from(progressStep) // ✅ 진행 단계 테이블을 기준으로 조회
             .leftJoin(approval).on(

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepositoryImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.checkping.infra.repository.approval;
+
+import static com.checkping.domain.approval.QApproval.approval;
+
+import com.checkping.domain.approval.Approval;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ApprovalCustomRepositoryImpl implements ApprovalCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public ApprovalCustomRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Long countByProgressStep(Long projectId, Long progressStepId) {
+        return queryFactory
+            .select(approval.count())
+            .from(approval)
+            .where(
+                approval.project.id.eq(projectId), // 프로젝트 ID
+                approval.progressStep.id.eq(progressStepId), // 진행상태 ID
+                approval.deleteYn.eq(Approval.DeleteStatus.N) // 삭제 여부
+            )
+            .fetchOne();
+    }
+}

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalReader.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalReader.java
@@ -14,4 +14,6 @@ public interface ApprovalReader {
     Page<Approval> getApprovals(Long projectId, ApprovalSearchInfo.SearchCondition searchCondition);
 
     boolean isContainingApproval(Long projectId, Long approvalId);
+
+    Long countByProgressStep(Long projectId, Long progressStepId);
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalReader.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalReader.java
@@ -1,7 +1,9 @@
 package com.checkping.infra.repository.approval;
 
 import com.checkping.domain.approval.Approval;
+import com.checkping.info.approval.ApprovalCountProjection;
 import com.checkping.info.approval.ApprovalSearchInfo;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 
@@ -15,5 +17,5 @@ public interface ApprovalReader {
 
     boolean isContainingApproval(Long projectId, Long approvalId);
 
-    Long countByProgressStep(Long projectId, Long progressStepId);
+    List<ApprovalCountProjection> countByProgressStep(Long projectId);
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalReaderImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalReaderImpl.java
@@ -1,7 +1,9 @@
 package com.checkping.infra.repository.approval;
 
 import com.checkping.domain.approval.Approval;
+import com.checkping.info.approval.ApprovalCountProjection;
 import com.checkping.info.approval.ApprovalSearchInfo;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -92,7 +94,7 @@ public class ApprovalReaderImpl implements ApprovalReader {
     }
 
     @Override
-    public Long countByProgressStep(Long projectId, Long progressStepId) {
-        return approvalRepository.countByProgressStep(projectId, progressStepId);
+    public List<ApprovalCountProjection> countByProgressStep(Long projectId) {
+        return approvalRepository.countByProgressStep(projectId);
     }
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalReaderImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalReaderImpl.java
@@ -90,4 +90,9 @@ public class ApprovalReaderImpl implements ApprovalReader {
     public boolean isContainingApproval(Long projectId, Long approvalId) {
         return approvalRepository.existsByProjectIdAndId(projectId, approvalId);
     }
+
+    @Override
+    public Long countByProgressStep(Long projectId, Long progressStepId) {
+        return approvalRepository.countByProgressStep(projectId, progressStepId);
+    }
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ApprovalRepository extends JpaRepository<Approval, Long> {
+public interface ApprovalRepository extends JpaRepository<Approval, Long>, ApprovalCustomRepository {
 
     @Query("SELECT a FROM Approval a "
         + "LEFT JOIN FETCH a.commentList c "

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalCount.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalCount.java
@@ -3,6 +3,8 @@ package com.checkping.dto.approval;
 import com.checkping.domain.project.ProgressStep;
 import com.checkping.info.approval.ApprovalCountProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
@@ -13,7 +15,7 @@ import lombok.NoArgsConstructor;
 public class ApprovalCount {
 
     @Getter
-    public static class Response {
+    public static class Response implements Comparable<ApprovalCount.Response> {
 
         /*
         id : progressStep ID
@@ -21,6 +23,7 @@ public class ApprovalCount {
         value : progressStep 값
         count : progressStep 카운트
         status : progressStep 상태
+        stepOrder : progressStep 순서
          */
         @Schema(description = "progressStep ID")
         private Long id;
@@ -32,6 +35,8 @@ public class ApprovalCount {
         private Long count;
         @Schema(description = "progressStep 상태")
         private String status;
+        @Schema(description = "progressStep 순서")
+        private Integer stepOrder;
 
         /**
          * 전체 카운트 생성
@@ -46,6 +51,7 @@ public class ApprovalCount {
             dto.value = "ALL";
             dto.count = count;
             dto.status = "ALL";
+            dto.stepOrder = -1;
             return dto;
         }
 
@@ -62,15 +68,15 @@ public class ApprovalCount {
             dto.value = approvalCountProjection.getValue();
             dto.count = approvalCountProjection.getCount();
             dto.status = approvalCountProjection.getStatus();
+            dto.stepOrder = approvalCountProjection.getStepOrder();
             return dto;
         }
 
         /**
-         * 도메인 모듈 - ApprovalCountProjection List -> ApprovalCount.Response List Dto
-         * 전체 카운트를 추가하여 반환
+         * 도메인 모듈 - ApprovalCountProjection List -> ApprovalCount.Response List Dto 전체 카운트를 추가하여 반환
          *
-         * @param approvalCountProjections  ApprovalCountProjection List
-         * @return  ApprovalCount.Response List Dto
+         * @param approvalCountProjections ApprovalCountProjection List
+         * @return ApprovalCount.Response List Dto
          */
         public static List<Response> toDto(List<ApprovalCountProjection> approvalCountProjections) {
 
@@ -83,7 +89,15 @@ public class ApprovalCount {
             Long totalCount = responseList.stream().mapToLong(Response::getCount).sum();
             responseList.add(makeEntireCount(totalCount));
 
+            // 정렬 (오름차순)
+            responseList.sort(Comparator.naturalOrder());
+
             return responseList;
+        }
+
+        @Override
+        public int compareTo(Response o) {
+            return this.id.compareTo(o.id);
         }
     }
 

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalCount.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalCount.java
@@ -1,7 +1,10 @@
 package com.checkping.dto.approval;
 
 import com.checkping.domain.project.ProgressStep;
+import com.checkping.info.approval.ApprovalCountProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,23 +34,6 @@ public class ApprovalCount {
         private String status;
 
         /**
-         * ProgressStep Entity -> ApprovalCount.Response Dto
-         *
-         * @param progressStep ProgressStep Entity
-         * @param count        progressStep 에 해당하는 결재 글의 개수
-         * @return ApprovalCount.Response Dto
-         */
-        public static Response toDto(ProgressStep progressStep, Long count) {
-            Response dto = new Response();
-            dto.id = progressStep.getId();
-            dto.title = progressStep.getName();
-            dto.value = progressStep.getDescription();
-            dto.count = count;
-            dto.status = progressStep.getStatus() != null ? progressStep.getStatus().name() : null;
-            return dto;
-        }
-
-        /**
          * 전체 카운트 생성
          *
          * @param count 전체 카운트
@@ -61,6 +47,43 @@ public class ApprovalCount {
             dto.count = count;
             dto.status = "ALL";
             return dto;
+        }
+
+        /**
+         * 도메인 모듈 - ApprovalCountProjection -> ApprovalCount.Response Dto
+         *
+         * @param approvalCountProjection ApprovalCountProjection
+         * @return ApprovalCount.Response Dto
+         */
+        public static Response toDto(ApprovalCountProjection approvalCountProjection) {
+            Response dto = new Response();
+            dto.id = approvalCountProjection.getId();
+            dto.title = approvalCountProjection.getTitle();
+            dto.value = approvalCountProjection.getValue();
+            dto.count = approvalCountProjection.getCount();
+            dto.status = approvalCountProjection.getStatus();
+            return dto;
+        }
+
+        /**
+         * 도메인 모듈 - ApprovalCountProjection List -> ApprovalCount.Response List Dto
+         * 전체 카운트를 추가하여 반환
+         *
+         * @param approvalCountProjections  ApprovalCountProjection List
+         * @return  ApprovalCount.Response List Dto
+         */
+        public static List<Response> toDto(List<ApprovalCountProjection> approvalCountProjections) {
+
+            // ApprovalCountProjection -> ApprovalCount.Response Dto
+            List<Response> responseList = approvalCountProjections.stream()
+                .map(ApprovalCount.Response::toDto)
+                .collect(Collectors.toList());
+
+            // 전체 카운트 추가
+            Long totalCount = responseList.stream().mapToLong(Response::getCount).sum();
+            responseList.add(makeEntireCount(totalCount));
+
+            return responseList;
         }
     }
 

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalCount.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalCount.java
@@ -1,0 +1,67 @@
+package com.checkping.dto.approval;
+
+import com.checkping.domain.project.ProgressStep;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApprovalCount {
+
+    @Getter
+    public static class Response {
+
+        /*
+        id : progressStep ID
+        title : progressStep 제목
+        value : progressStep 값
+        count : progressStep 카운트
+        status : progressStep 상태
+         */
+        @Schema(description = "progressStep ID")
+        private Long id;
+        @Schema(description = "progressStep 제목")
+        private String title;
+        @Schema(description = "progressStep 값")
+        private String value;
+        @Schema(description = "progressStep 에 해당하는 결재 글의 개수")
+        private Long count;
+        @Schema(description = "progressStep 상태")
+        private String status;
+
+        /**
+         * ProgressStep Entity -> ApprovalCount.Response Dto
+         *
+         * @param progressStep ProgressStep Entity
+         * @param count        progressStep 에 해당하는 결재 글의 개수
+         * @return ApprovalCount.Response Dto
+         */
+        public static Response toDto(ProgressStep progressStep, Long count) {
+            Response dto = new Response();
+            dto.id = progressStep.getId();
+            dto.title = progressStep.getName();
+            dto.value = progressStep.getDescription();
+            dto.count = count;
+            dto.status = progressStep.getStatus() != null ? progressStep.getStatus().name() : null;
+            return dto;
+        }
+
+        /**
+         * 전체 카운트 생성
+         *
+         * @param count 전체 카운트
+         * @return 전체 카운트 Response
+         */
+        public static Response makeEntireCount(Long count) {
+            Response dto = new Response();
+            dto.id = 0L;
+            dto.title = "전체";
+            dto.value = "ALL";
+            dto.count = count;
+            dto.status = "ALL";
+            return dto;
+        }
+    }
+
+}

--- a/module-service/src/main/java/com/checkping/service/approval/ApprovalService.java
+++ b/module-service/src/main/java/com/checkping/service/approval/ApprovalService.java
@@ -1,6 +1,7 @@
 package com.checkping.service.approval;
 
 import com.checkping.dto.approval.ApprovalConfirm;
+import com.checkping.dto.approval.ApprovalCount;
 import com.checkping.dto.approval.ApprovalDelete;
 import com.checkping.dto.approval.ApprovalGet;
 import com.checkping.dto.approval.ApprovalRegister;
@@ -9,6 +10,7 @@ import com.checkping.dto.approval.ApprovalSearchCondition;
 import com.checkping.dto.approval.ApprovalUpdate;
 import com.checkping.dto.approval.comment.ApprovalCommentRegister;
 import com.checkping.dto.approval.comment.ApprovalReCommentRegister;
+import java.util.List;
 
 public interface ApprovalService {
 
@@ -30,4 +32,6 @@ public interface ApprovalService {
 
     ApprovalConfirm.Response confirm(Long projectId, Long approvalId,
         ApprovalConfirm.Request request);
+
+    List<ApprovalCount.Response> count(Long projectId);
 }

--- a/module-service/src/main/java/com/checkping/service/approval/ApprovalService.java
+++ b/module-service/src/main/java/com/checkping/service/approval/ApprovalService.java
@@ -33,5 +33,5 @@ public interface ApprovalService {
     ApprovalConfirm.Response confirm(Long projectId, Long approvalId,
         ApprovalConfirm.Request request);
 
-    List<ApprovalCount.Response> count(Long projectId);
+    List<ApprovalCount.Response> countByProgressStep(Long projectId);
 }

--- a/module-service/src/main/java/com/checkping/service/approval/ApprovalServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/approval/ApprovalServiceImpl.java
@@ -8,6 +8,7 @@ import com.checkping.domain.member.Member;
 import com.checkping.domain.project.ProgressStep;
 import com.checkping.domain.project.Project;
 import com.checkping.dto.approval.ApprovalConfirm;
+import com.checkping.dto.approval.ApprovalCount;
 import com.checkping.dto.approval.ApprovalDelete;
 import com.checkping.dto.approval.ApprovalGet;
 import com.checkping.dto.approval.ApprovalRegister;
@@ -333,6 +334,20 @@ public class ApprovalServiceImpl implements ApprovalService {
         }
 
         return ApprovalConfirm.Response.toDto(approval);
+    }
+
+    @Override
+    public List<ApprovalCount.Response> count(Long projectId) {
+
+        // Find Member
+
+        // Find project
+
+        // Find progressSteps
+
+
+
+        return List.of();
     }
 
     /**

--- a/module-service/src/main/java/com/checkping/service/approval/ApprovalServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/approval/ApprovalServiceImpl.java
@@ -31,6 +31,7 @@ import com.checkping.exception.approval.comment.ApprovalCommentMismatchException
 import com.checkping.exception.approval.comment.ApprovalCommentNotFoundEntityException;
 import com.checkping.exception.project.progressstep.ProgressStepMismatchProjectException;
 import com.checkping.exception.project.progressstep.ProgressStepNotFoundException;
+import com.checkping.info.approval.ApprovalCountProjection;
 import com.checkping.info.approval.ApprovalSearchInfo;
 import com.checkping.infra.repository.approval.ApprovalReader;
 import com.checkping.infra.repository.approval.ApprovalStore;
@@ -336,18 +337,15 @@ public class ApprovalServiceImpl implements ApprovalService {
         return ApprovalConfirm.Response.toDto(approval);
     }
 
+    @Transactional(readOnly = true)
     @Override
-    public List<ApprovalCount.Response> count(Long projectId) {
+    public List<ApprovalCount.Response> countByProgressStep(Long projectId) {
 
-        // Find Member
+        // Approval count by progress step
+        List<ApprovalCountProjection> queryResult = approvalReader.countByProgressStep(projectId);
 
-        // Find project
-
-        // Find progressSteps
-
-
-
-        return List.of();
+        // Entity -> Response
+        return ApprovalCount.Response.toDto(queryResult);
     }
 
     /**


### PR DESCRIPTION
# 🚀 Pull Request

**[결재 게시글 개수 조회 기능]**

## #️⃣ 연관된 이슈

- #402 

## 📋 작업 내용

- QueryDSL 을 적용하기 위해서 ApprovalCustomRepository 를 생성하고 구현하였습니다.
- countByProgressStep 의 쿼리가 groupBy 로 인해서 반환값이 Tuple 로 반환됩니다.
이 튜플을 그대로 반환하여서 서비스 모듈이나 인프라 모듈에서 반환하는 것은 추후에 queryDSL이 아닌 다른 것을 사용할 때 위험할 것이라고 판단했습니다.
그래서 Projection 이라는 것을 사용하였습니다.
하지만 Q 클래스를 빌드하는 의존성은 도메인 모듈에만 존재하기 때문에 Projection 클래스를 도메인에 두게 되었습니다.
