### PR TITLE
Feature/403 feature 결재 목록 조회 수정

### DIFF
--- a/module-domain/src/main/java/com/checkping/info/approval/ApprovalSearchInfo.java
+++ b/module-domain/src/main/java/com/checkping/info/approval/ApprovalSearchInfo.java
@@ -15,14 +15,15 @@ public class ApprovalSearchInfo {
     pageSize: 페이지 사이즈
      */
 
-    public record SearchCondition(Long progressId, ApprovalStatus status, String keyword,
+    public record SearchCondition(Long progressId, ApprovalStatus status, String keyword, boolean adminSearch,
                                   Integer currentPage, Integer pageSize) {
 
-        public SearchCondition(Long progressId, ApprovalStatus status, String keyword,
+        public SearchCondition(Long progressId, ApprovalStatus status, String keyword, boolean adminSearch,
             Integer currentPage, Integer pageSize) {
             this.progressId = progressId;
             this.status = status;
             this.keyword = keyword;
+            this.adminSearch = adminSearch;
 
             // currentPage 와 pageSize 가 null 이거나 0 이하일 경우 기본값으로 1, 10 으로 설정
             if (currentPage == null || currentPage < 0) {

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepository.java
@@ -1,9 +1,16 @@
 package com.checkping.infra.repository.approval;
 
+import com.checkping.domain.approval.Approval;
 import com.checkping.info.approval.ApprovalCountProjection;
+import com.checkping.info.approval.ApprovalSearchInfo.SearchCondition;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ApprovalCustomRepository {
 
     List<ApprovalCountProjection> countByProgressStep(Long projectId);
+
+    Page<Approval> getByCondition(Long projectId, SearchCondition searchCondition,
+        Pageable pageable);
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepository.java
@@ -2,7 +2,7 @@ package com.checkping.infra.repository.approval;
 
 import com.checkping.domain.approval.Approval;
 import com.checkping.info.approval.ApprovalCountProjection;
-import com.checkping.info.approval.ApprovalSearchInfo.SearchCondition;
+import com.checkping.info.approval.ApprovalSearchInfo;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +11,6 @@ public interface ApprovalCustomRepository {
 
     List<ApprovalCountProjection> countByProgressStep(Long projectId);
 
-    Page<Approval> getByCondition(Long projectId, SearchCondition searchCondition,
+    Page<Approval> getByCondition(Long projectId, ApprovalSearchInfo.SearchCondition searchCondition,
         Pageable pageable);
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepositoryImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepositoryImpl.java
@@ -5,11 +5,18 @@ import static com.checkping.domain.project.QProgressStep.progressStep;
 
 import com.checkping.domain.approval.Approval;
 import com.checkping.info.approval.ApprovalCountProjection;
+import com.checkping.info.approval.ApprovalSearchInfo.SearchCondition;
 import com.checkping.info.approval.QApprovalCountProjection;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 @Repository
 public class ApprovalCustomRepositoryImpl implements ApprovalCustomRepository {
@@ -23,25 +30,65 @@ public class ApprovalCustomRepositoryImpl implements ApprovalCustomRepository {
     @Override
     public List<ApprovalCountProjection> countByProgressStep(Long projectId) {
 
-        JPAQuery<ApprovalCountProjection> query = queryFactory
-            .select(new QApprovalCountProjection(
-                progressStep.id,                     // ✅ 진행 단계 ID
-                progressStep.name,                   // ✅ 진행 단계 이름
-                progressStep.description,            // ✅ 진행 단계 설명
-                approval.count().coalesce(0L),       // ✅ 개수가 없으면 0 반환
-                progressStep.status.stringValue() // ✅ 진행 단계 상태
-            ))
-            .from(progressStep) // ✅ 진행 단계 테이블을 기준으로 조회
-            .leftJoin(approval).on(
-                approval.progressStep.id.eq(progressStep.id)
-                    .and(approval.project.id.eq(projectId)) // 특정 프로젝트 내에서만 조회
-                    .and(approval.deleteYn.eq(Approval.DeleteStatus.N)) // 삭제되지 않은 데이터만 포함
-            )
-            .where(
-                progressStep.projectId.eq(projectId) // ✅ 프로젝트 ID 조건
-            )
-            .groupBy(progressStep.id); // ✅ 진행 단계 ID로 그룹화
+        JPAQuery<ApprovalCountProjection> query = queryFactory.select(
+                new QApprovalCountProjection(progressStep.id,                     // ✅ 진행 단계 ID
+                    progressStep.name,                   // ✅ 진행 단계 이름
+                    progressStep.description,            // ✅ 진행 단계 설명
+                    approval.count().coalesce(0L),       // ✅ 개수가 없으면 0 반환
+                    progressStep.status.stringValue() // ✅ 진행 단계 상태
+                )).from(progressStep) // ✅ 진행 단계 테이블을 기준으로 조회
+            .leftJoin(approval).on(approval.progressStep.id.eq(progressStep.id)
+                .and(approval.project.id.eq(projectId)) // 특정 프로젝트 내에서만 조회
+                .and(approval.deleteYn.eq(Approval.DeleteStatus.N)) // 삭제되지 않은 데이터만 포함
+            ).where(progressStep.projectId.eq(projectId) // ✅ 프로젝트 ID 조건
+            ).groupBy(progressStep.id); // ✅ 진행 단계 ID로 그룹화
 
         return query.fetch();
+    }
+
+    @Override
+    public Page<Approval> getByCondition(Long projectId, SearchCondition searchCondition,
+        Pageable pageable) {
+
+        // ✅ 동적 검색 조건을 위한 BooleanBuilder
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // ✅ 필수 조건: 프로젝트 ID
+        builder.and(approval.project.id.eq(projectId));
+
+        // ✅ 필수 조건: 삭제되지 않은 데이터만 조회
+        builder.and(approval.deleteYn.eq(Approval.DeleteStatus.N));
+
+        // ✅ 검색어 조건 (title에 포함된 검색어)
+        if (StringUtils.hasText(searchCondition.keyword())) {
+            builder.and(approval.title.containsIgnoreCase(searchCondition.keyword()));
+        }
+
+        // ✅ 상태 조건
+        if (searchCondition.status() != null) {
+            builder.and(approval.status.eq(searchCondition.status()));
+        }
+
+        // ✅ 진행 단계 조건
+        if (searchCondition.progressId() != null) {
+            builder.and(approval.progressStep.id.eq(searchCondition.progressId()));
+        }
+
+        // ✅ 총 개수 조회
+        long total = Optional.ofNullable(
+                queryFactory
+                    .select(approval.count())
+                    .from(approval)
+                    .where(builder)
+                    .fetchOne())
+            .orElse(0L);
+
+        // ✅ 페이징된 데이터 조회
+        List<Approval> approvals = queryFactory.selectFrom(approval).where(builder)
+            .offset(pageable.getOffset()) // ✅ 페이징 처리 (시작 위치)
+            .limit(pageable.getPageSize()) // ✅ 페이지 크기 지정
+            .fetch();
+
+        return new PageImpl<>(approvals, pageable, total);
     }
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepositoryImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepositoryImpl.java
@@ -56,8 +56,10 @@ public class ApprovalCustomRepositoryImpl implements ApprovalCustomRepository {
         // ✅ 필수 조건: 프로젝트 ID
         builder.and(approval.project.id.eq(projectId));
 
-        // ✅ 필수 조건: 삭제되지 않은 데이터만 조회
-        builder.and(approval.deleteYn.eq(Approval.DeleteStatus.N));
+        // ✅ 삭제상태 조건: 삭제되지 않은 데이터만 조회 (
+        if(!searchCondition.adminSearch()) {
+            builder.and(approval.deleteYn.eq(Approval.DeleteStatus.N));
+        }
 
         // ✅ 검색어 조건 (title에 포함된 검색어)
         if (StringUtils.hasText(searchCondition.keyword())) {

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalReaderImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalReaderImpl.java
@@ -35,57 +35,7 @@ public class ApprovalReaderImpl implements ApprovalReader {
         Pageable pageable = PageRequest.of(searchCondition.currentPage(),
             searchCondition.pageSize());
 
-        // keyword / status / progressStep 검색 조건 여부 확인
-        boolean isKeyword = searchCondition.keyword() != null && !searchCondition.keyword()
-            .isEmpty();
-        boolean isStatus = searchCondition.status() != null;
-        boolean isProgressStep = searchCondition.progressId() != null;
-
-        // Search all - 검색 조건이 없는 경우
-        if (!isKeyword && !isStatus && !isProgressStep) {
-            return approvalRepository.findByProjectId(projectId, pageable);
-        }
-
-        // Search keyword - 검색어만 있는 경우
-        if (isKeyword && !isStatus && !isProgressStep) {
-            return approvalRepository.findByProjectIdAndTitleContaining(
-                projectId, searchCondition.keyword(), pageable);
-        }
-
-        // Search status - 상태만 있는 경우
-        if (!isKeyword && isStatus && !isProgressStep) {
-            return approvalRepository.findByProjectIdAndStatus(
-                projectId, searchCondition.status(), pageable);
-        }
-
-        // Search progressStep - 진행상태만 있는 경우
-        if (!isKeyword && !isStatus && isProgressStep) {
-            return approvalRepository.findByProjectIdAndProgressStepId(
-                projectId, searchCondition.progressId(), pageable);
-        }
-
-        // Search keyword and status - 검색어와 상태가 있는 경우
-        if (isKeyword && isStatus && !isProgressStep) {
-            return approvalRepository.findByProjectIdAndTitleContainingAndStatus(
-                projectId, searchCondition.keyword(), searchCondition.status(), pageable);
-        }
-
-        // Search keyword and progressStep - 검색어와 진행상태가 있는 경우
-        if (isKeyword && !isStatus && isProgressStep) {
-            return approvalRepository.findByProjectIdAndTitleContainingAndProgressStepId(
-                projectId, searchCondition.keyword(), searchCondition.progressId(), pageable);
-        }
-
-        // Search status and progressStep - 상태와 진행상태가 있는 경우
-        if (!isKeyword && isStatus && isProgressStep) {
-            return approvalRepository.findByProjectIdAndProgressStepIdAndStatus(
-                projectId, searchCondition.progressId(), searchCondition.status(), pageable);
-        }
-
-        // Search keyword and status and progressStep - 검색어와 상태와 진행상태가 있는 경우
-        return approvalRepository.findByProjectIdAndTitleContainingAndProgressStepIdAndStatus(
-            projectId, searchCondition.keyword(), searchCondition.progressId(),
-            searchCondition.status(), pageable);
+        return approvalRepository.getByCondition(projectId, searchCondition, pageable);
     }
 
     @Override

--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalRepository.java
@@ -2,8 +2,6 @@ package com.checkping.infra.repository.approval;
 
 import com.checkping.domain.approval.Approval;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,22 +15,6 @@ public interface ApprovalRepository extends JpaRepository<Approval, Long>, Appro
         + "WHERE a.id = :approvalId "
         + "ORDER BY COALESCE(c.parent.id, c.id), c.regAt ASC")
     Optional<Approval> getByIdWithComments(@Param("approvalId") Long approvalId);
-
-    Page<Approval> findByProjectId(Long projectId, Pageable pageable);
-
-    Page<Approval> findByProjectIdAndTitleContaining(Long projectId, String title, Pageable pageable);
-
-    Page<Approval> findByProjectIdAndStatus(Long projectId, Approval.ApprovalStatus status, Pageable pageable);
-
-    Page<Approval> findByProjectIdAndProgressStepId(Long projectId, Long progressStepId, Pageable pageable);
-
-    Page<Approval> findByProjectIdAndTitleContainingAndStatus(Long projectId, String title, Approval.ApprovalStatus status, Pageable pageable);
-
-    Page<Approval> findByProjectIdAndTitleContainingAndProgressStepId(Long projectId, String title, Long progressStepId, Pageable pageable);
-
-    Page<Approval> findByProjectIdAndProgressStepIdAndStatus(Long projectId, Long progressStepId, Approval.ApprovalStatus status, Pageable pageable);
-
-    Page<Approval> findByProjectIdAndTitleContainingAndProgressStepIdAndStatus(Long projectId, String title, Long progressStepId, Approval.ApprovalStatus status, Pageable pageable);
 
     boolean existsByProjectIdAndId(Long projectId, Long approvalId);
 }

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalSearch.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalSearch.java
@@ -29,6 +29,7 @@ public class ApprovalSearch {
         approvalAt : 결재일
         approval : 결재자
         cancelAt : 취소일
+        isDeleted : 삭제 여부
          */
         private Long id;
         private Long projectId;
@@ -41,6 +42,8 @@ public class ApprovalSearch {
         private String approverAt;
         private MeResponseDto approver;
         private String cancelAt;
+        private boolean isDeleted;
+
 
         /**
          * Approval Entity -> ApprovalItem Dto
@@ -61,6 +64,7 @@ public class ApprovalSearch {
             dto.approverAt = DateTimeUtils.format(approval.getApproverAt());
             dto.approver = approval.getApprover() == null ? null : MeResponseDto.fromEntity(approval.getApprover());
             dto.cancelAt = DateTimeUtils.format(approval.getCancelAt());
+            dto.isDeleted = approval.getDeleteYn() == Approval.DeleteStatus.Y;
             return dto;
         }
 

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalSearch.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalSearch.java
@@ -26,7 +26,7 @@ public class ApprovalSearch {
         register : 작성자
         regAt : 작성일
         updatedAt : 수정일
-        approvalAt : 결재일
+        approvedAt : 결재일
         approval : 결재자
         cancelAt : 취소일
         isDeleted : 삭제 여부
@@ -39,7 +39,7 @@ public class ApprovalSearch {
         private MeResponseDto register;
         private String regAt;
         private String updatedAt;
-        private String approverAt;
+        private String approvedAt;
         private MeResponseDto approver;
         private String cancelAt;
         private boolean isDeleted;
@@ -61,7 +61,7 @@ public class ApprovalSearch {
             dto.register = MeResponseDto.fromEntity(approval.getRegister());
             dto.regAt = DateTimeUtils.format(approval.getRegAt());
             dto.updatedAt = DateTimeUtils.format(approval.getUpdatedAt());
-            dto.approverAt = DateTimeUtils.format(approval.getApproverAt());
+            dto.approvedAt = DateTimeUtils.format(approval.getApproverAt());
             dto.approver = approval.getApprover() == null ? null : MeResponseDto.fromEntity(approval.getApprover());
             dto.cancelAt = DateTimeUtils.format(approval.getCancelAt());
             dto.isDeleted = approval.getDeleteYn() == Approval.DeleteStatus.Y;

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalSearchCondition.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalSearchCondition.java
@@ -23,11 +23,12 @@ public class ApprovalSearchCondition {
     private Integer pageSize;
 
     public static ApprovalSearchInfo.SearchCondition toInfo(
-        ApprovalSearchCondition searchCondition) {
+        ApprovalSearchCondition searchCondition, boolean adminSearch) {
         return new ApprovalSearchInfo.SearchCondition(
             searchCondition.getProgressId(),
             ApprovalSearchCondition.convertStatus(searchCondition.getStatus()),
             searchCondition.getKeyword(),
+            adminSearch,
             searchCondition.getCurrentPage(), searchCondition.getPageSize());
     }
 

--- a/module-service/src/main/java/com/checkping/service/approval/ApprovalServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/approval/ApprovalServiceImpl.java
@@ -112,9 +112,12 @@ public class ApprovalServiceImpl implements ApprovalService {
     @Transactional(readOnly = true)
     public ApprovalSearch.Response search(Long projectId, ApprovalSearchCondition request) {
 
+        // 어드민일 때 조회 권한 추가
+        boolean adminSearch = false;
+
         // ApprovalSearchCondition -> ApprovalSearchInfo.SearchCondition
-        ApprovalSearchInfo.SearchCondition searchCondition = ApprovalSearchCondition.toInfo(
-            request);
+        ApprovalSearchInfo.SearchCondition searchCondition = ApprovalSearchCondition.toInfo(request,
+            adminSearch);
 
         // Search Approval
         Page<Approval> approvals = approvalReader.getApprovals(projectId, searchCondition);
@@ -414,8 +417,8 @@ public class ApprovalServiceImpl implements ApprovalService {
     /**
      * 결재 작성자와 현재 사용자가 같은지 확인
      *
-     * @param member    현재 사용자
-     * @param approval  결재 Entity
+     * @param member   현재 사용자
+     * @param approval 결재 Entity
      * @throws ApprovalRegisterAuthorityException 결재 작성자 권한 예외
      */
     private void checkRegisterAuthority(Member member, Approval approval) {


### PR DESCRIPTION
# 🚀 Pull Request

**[결재 목록 조회 수정]**

## #️⃣ 연관된 이슈

- #403 

## 📋 작업 내용

- 기존에 조회 메서드를 쿼리 메서드로만 처리하던 것을 queryDsl의 동적쿼리를 사용하여 처리하도록 변경하였습니다.
- 삭제되지 않은 결재 글을 조회하는 기능과 삭제된 결재 글도 조회하는 기능을 추가하였습니다.
