### PR TITLE
Chore/389 chore 프로젝트 엔티티 status 제거

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/ProjectController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/ProjectController.java
@@ -53,12 +53,12 @@ public class ProjectController implements ProjectApi {
     @GetMapping(value = {"/admins/projects", "/projects"})
     public BaseResponse<ProjectResponse.ProjectListDto> listProjects(
             @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String managementStep,
             @RequestParam(defaultValue = "1") int currentPage,
             @RequestParam(defaultValue = "10") int pageSize
             ) {
 
-        ProjectResponse.ProjectListDto projects = projectService.findAllProjects(keyword, status, currentPage, pageSize);
+        ProjectResponse.ProjectListDto projects = projectService.findAllProjects(keyword, managementStep, currentPage, pageSize);
         //log.info("FlowSync - getProjectlist : ");
         return BaseResponse.success(projects);
     }

--- a/module-domain/src/main/java/com/checkping/domain/project/Project.java
+++ b/module-domain/src/main/java/com/checkping/domain/project/Project.java
@@ -51,10 +51,6 @@ public class Project extends BaseEntity {
     private String detail;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", length = 100)
-    private Status status;
-
-    @Enumerated(EnumType.STRING)
     @Column(name = "management_step", length = 100)
     private ManagementStep managementStep;
 

--- a/module-infra/src/main/java/com/checkping/infra/dto/ProjectUpdateDetailsDto.java
+++ b/module-infra/src/main/java/com/checkping/infra/dto/ProjectUpdateDetailsDto.java
@@ -14,7 +14,6 @@ public class ProjectUpdateDetailsDto {
     private final String name;
     private final String description;
     private final String detail;
-    private final String status;
     private final String managementStep;
     private final Long progressStepId;
     private final Date startAt;

--- a/module-infra/src/main/java/com/checkping/infra/dto/ProjectUpdateDetailsDto.java
+++ b/module-infra/src/main/java/com/checkping/infra/dto/ProjectUpdateDetailsDto.java
@@ -15,7 +15,6 @@ public class ProjectUpdateDetailsDto {
     private final String description;
     private final String detail;
     private final String managementStep;
-    private final Long progressStepId;
     private final Date startAt;
     private final Date closeAt;
     private final Long devOwnerId;

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectRepository.java
@@ -3,7 +3,6 @@ package com.checkping.infra.repository.project;
 import com.checkping.domain.project.Project;
 import com.checkping.infra.dto.ProjectDetailsDto;
 import com.checkping.infra.dto.ProjectUpdateDetailsDto;
-import com.checkping.infra.repository.project.projection.ProjectInfoProjection;
 import com.checkping.infra.repository.project.querydsl.ProjectRepositoryCustom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,7 +17,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
 
     @Query(value =
             "SELECT " +
-            "p.id, p.name, p.description, p.detail, p.status, p.management_step, " +
+            "p.id, p.name, p.description, p.detail, p.management_step, " +
             "p.reg_at, p.update_at, p.start_at, p.close_at, p.deleted_yn, p.dev_owner_id, " +
             "org_info.developer_name, org_info.customer_name, 1 AS clickable " +
             "FROM project p " +
@@ -31,12 +30,12 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
             "    GROUP BY obp.project_id " +
             ") AS org_info ON p.id = org_info.project_id " +
             "WHERE (NULLIF(:keyword, '') IS NULL OR p.name LIKE CONCAT('%', :keyword, '%')) " +
-            "AND (NULLIF(:status, '') IS NULL OR p.status = :status)", nativeQuery = true)
-    Page<Object[]> findAdminProjectsByKeywordAndStatus(@Param("keyword") String keyword, @Param("status") String status, @Param("pageable") Pageable pageable);
+            "AND (NULLIF(:managementStep, '') IS NULL OR p.management_step = :managementStep)", nativeQuery = true)
+    Page<Object[]> findAdminProjectsByKeywordAndManagementStep(@Param("keyword") String keyword, @Param("managementStep") String managementStep, @Param("pageable") Pageable pageable);
 
     @Query(value =
             "SELECT " +
-            "p.id, p.name, p.description, p.detail, p.status, p.management_step, " +
+            "p.id, p.name, p.description, p.detail, p.management_step, " +
             "p.reg_at, p.update_at, p.start_at, p.close_at, p.deleted_yn, p.dev_owner_id, " +
             "org_info.developer_name, org_info.customer_name, " +
             "(SELECT CASE WHEN EXISTS (SELECT 1 FROM member_by_project mbp WHERE mbp.project_id=p.id AND mbp.member_id=m.id) THEN 1 ELSE 0 END) AS clickable " +
@@ -54,7 +53,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
             "    GROUP BY mbp.project_id " +
             ") AS org_info ON p.id = org_info.project_id " +
             "WHERE (NULLIF(:keyword, '') IS NULL OR p.name LIKE CONCAT('%', :keyword, '%')) " +
-            "AND (NULLIF(:status, '') IS NULL OR p.status = :status)" +
+            "AND (NULLIF(:managementStep, '') IS NULL OR p.management_step = :managementStep)" +
             "AND m.id = :memberId ",
             countQuery =
                     "SELECT COUNT(p.id) " +
@@ -63,13 +62,13 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
                             "LEFT JOIN organization o ON obp.org_id = o.id " +
                             "LEFT JOIN member m ON o.id = m.org_id " +
                             "WHERE (NULLIF(:keyword, '') IS NULL OR p.name LIKE CONCAT('%', :keyword, '%')) " +
-                            "AND (NULLIF(:status, '') IS NULL OR p.status = :status) " +
+                            "AND (NULLIF(:managementStep, '') IS NULL OR p.management_step = :managementStep) " +
                             "AND m.id = :memberId", nativeQuery = true)
-    Page<Object[]> findDeveloperProjectsByKeywordAndStatus(@Param("keyword") String keyword, @Param("status") String status, @Param("pageable") Pageable pageable, @Param("memberId") Long memberId);
+    Page<Object[]> findDeveloperProjectsByKeywordAndManagementStep(@Param("keyword") String keyword, @Param("managementStep") String managementStep, @Param("pageable") Pageable pageable, @Param("memberId") Long memberId);
 
     @Query(value =
             "SELECT " +
-            "p.id, p.name, p.description, p.detail, p.status, p.management_step, " +
+            "p.id, p.name, p.description, p.detail, p.management_step, " +
             "p.reg_at, p.update_at, p.start_at, p.close_at, p.deleted_yn, p.dev_owner_id, " +
             "org_info.developer_name, org_info.customer_name, 1 AS clickable " +
             "FROM project p " +
@@ -85,9 +84,9 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
             "    GROUP BY mbp.project_id " +
             ") AS org_info ON p.id = org_info.project_id " +
             "WHERE (NULLIF(:keyword, '') IS NULL OR p.name LIKE CONCAT('%', :keyword, '%')) " +
-            "AND (NULLIF(:status, '') IS NULL OR p.status = :status)" +
+            "AND (NULLIF(:managementStep, '') IS NULL OR p.management_step = :managementStep)" +
             "AND m.id = :memberId ", nativeQuery = true)
-    Page<Object[]> findCustomerProjectsByKeywordAndStatus(@Param("keyword") String keyword, @Param("status") String status, @Param("pageable") Pageable pageable, @Param("memberId") Long memberId);
+    Page<Object[]> findCustomerProjectsByKeywordAndManagementStep(@Param("keyword") String keyword, @Param("managementStep") String managementStep, @Param("pageable") Pageable pageable, @Param("memberId") Long memberId);
 
     @Query(value = "SELECT " +
             "    p.id, " +
@@ -107,9 +106,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
             "WHERE p.id = :projectId", nativeQuery = true)
     Optional<ProjectDetailsDto> findProjectById(@Param("projectId") Long projectId);
 
-    List<ProjectInfoProjection> findByStatus(Project.Status status);
-
-    @Query(value = "SELECT p.id, p.name, p.description, p.detail, p.status, p.management_step, p.progress_step_id, p.start_at, p.close_at, p.dev_owner_id, " +
+    @Query(value = "SELECT p.id, p.name, p.description, p.detail, p.management_step, p.progress_step_id, p.start_at, p.close_at, p.dev_owner_id, " +
             "org_info.developer_org_id, " +
             "org_info.customer_org_id " +
             "FROM project p " +

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectRepository.java
@@ -106,7 +106,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
             "WHERE p.id = :projectId", nativeQuery = true)
     Optional<ProjectDetailsDto> findProjectById(@Param("projectId") Long projectId);
 
-    @Query(value = "SELECT p.id, p.name, p.description, p.detail, p.management_step, p.progress_step_id, p.start_at, p.close_at, p.dev_owner_id, " +
+    @Query(value = "SELECT p.id, p.name, p.description, p.detail, p.management_step, p.start_at, p.close_at, p.dev_owner_id, " +
             "org_info.developer_org_id, " +
             "org_info.customer_org_id " +
             "FROM project p " +

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/projection/ProjectInfoProjection.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/projection/ProjectInfoProjection.java
@@ -1,7 +1,0 @@
-package com.checkping.infra.repository.project.projection;
-
-public interface ProjectInfoProjection {
-    String getName();
-
-    Long getId();
-}

--- a/module-service/src/main/java/com/checkping/dto/project/ProjectRequest.java
+++ b/module-service/src/main/java/com/checkping/dto/project/ProjectRequest.java
@@ -28,7 +28,6 @@ public class ProjectRequest {
         description : 프로젝트 설명
         detail : 프로젝트 세부 설명
         managementStep : 프로젝트 관리 단계 * CONTRACT(계약), IN_PROGRESS(진행중), COMPLETED(납품완료), MAINTENANCE(하자보수), PAUSED(일시중단)
-        progressStepId : 프로젝트 현재 진행단계 아이디
         startAt : 프로젝트 시작 일시
         closeAt : 프로젝트 종료 일시
         resisterId : 등록자 아이디
@@ -46,8 +45,6 @@ public class ProjectRequest {
         private String detail;
         @Schema(description = "프로젝트 관리단계", example = "IN_PROGRESS")
         private String managementStep;
-        @Schema(description = "프로젝트 현재 진행단계 아이디", example = "1")
-        private Long progressStepId;
         @Schema(description = "프로젝트 시작 일시", example = "2025-01-15 10:17:15", type = "string")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime startAt;
@@ -99,7 +96,6 @@ public class ProjectRequest {
        description : 프로젝트 설명
        detail : 프로젝트 세부 설명
        managementStep : 프로젝트 관리 단계 * CONTRACT(계약), IN_PROGRESS(진행중), COMPLETED(납품완료), MAINTENANCE(하자보수), PAUSED(일시중단)
-       progressStepId : 프로젝트 현재 진행단계 아이디
        startAt : 프로젝트 시작 일시
        closeAt : 프로젝트 종료 일시
        devOwnerId : 개발사 대표자 아이디

--- a/module-service/src/main/java/com/checkping/dto/project/ProjectRequest.java
+++ b/module-service/src/main/java/com/checkping/dto/project/ProjectRequest.java
@@ -27,7 +27,6 @@ public class ProjectRequest {
         name : 프로젝트 이름
         description : 프로젝트 설명
         detail : 프로젝트 세부 설명
-        status : 프로젝트 상태 * IN_PROGRESS(진행중), PAUSED(일시 중단), COMPLETED(완료)
         managementStep : 프로젝트 관리 단계 * CONTRACT(계약), IN_PROGRESS(진행중), COMPLETED(납품완료), MAINTENANCE(하자보수), PAUSED(일시중단)
         progressStepId : 프로젝트 현재 진행단계 아이디
         startAt : 프로젝트 시작 일시
@@ -45,8 +44,6 @@ public class ProjectRequest {
         private String description;
         @Schema(description = "프로젝트 긴 설명")
         private String detail;
-        @Schema(description = "프로젝트 상태", example = "IN_PROGRESS")
-        private String status;
         @Schema(description = "프로젝트 관리단계", example = "IN_PROGRESS")
         private String managementStep;
         @Schema(description = "프로젝트 현재 진행단계 아이디", example = "1")
@@ -80,7 +77,6 @@ public class ProjectRequest {
                 .name(resisterDto.getName())
                 .description(resisterDto.getDescription())
                 .detail(resisterDto.getDetail())
-                .status(Project.Status.valueOf(resisterDto.getStatus()))
                 .managementStep(Project.ManagementStep.valueOf(resisterDto.getManagementStep()))
                 .regAt(LocalDateTime.now())
                 .startAt(resisterDto.getStartAt())
@@ -102,7 +98,6 @@ public class ProjectRequest {
        name : 프로젝트 이름
        description : 프로젝트 설명
        detail : 프로젝트 세부 설명
-       status : 프로젝트 상태 * IN_PROGRESS(진행중), PAUSED(일시 중단), COMPLETED(완료)
        managementStep : 프로젝트 관리 단계 * CONTRACT(계약), IN_PROGRESS(진행중), COMPLETED(납품완료), MAINTENANCE(하자보수), PAUSED(일시중단)
        progressStepId : 프로젝트 현재 진행단계 아이디
        startAt : 프로젝트 시작 일시
@@ -119,8 +114,6 @@ public class ProjectRequest {
         private String description;
         @Schema(description = "프로젝트 긴 설명")
         private String detail;
-        @Schema(description = "프로젝트 상태", example = "PAUSED")
-        private String status;
         @Schema(description = "프로젝트 관리단계", example = "COMPLETED")
         private String managementStep;
         @Schema(description = "프로젝트 현재 진행단계 아이디", example = "2")
@@ -155,7 +148,6 @@ public class ProjectRequest {
                 .name(updateDto.getName())
                 .description(updateDto.getDescription())
                 .detail(updateDto.getDetail())
-                .status(Project.Status.valueOf(updateDto.getStatus()))
                 .managementStep(Project.ManagementStep.valueOf(updateDto.getManagementStep()))
                 .progressStepId(updateDto.getProgressStepId())
                 .devOwner(devOwnerMember)

--- a/module-service/src/main/java/com/checkping/dto/project/ProjectRequest.java
+++ b/module-service/src/main/java/com/checkping/dto/project/ProjectRequest.java
@@ -112,8 +112,6 @@ public class ProjectRequest {
         private String detail;
         @Schema(description = "프로젝트 관리단계", example = "COMPLETED")
         private String managementStep;
-        @Schema(description = "프로젝트 현재 진행단계 아이디", example = "2")
-        private Long progressStepId;
         @Schema(description = "프로젝트 시작 일시", example = "2025-01-15 10:17:15", type = "string")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime startAt;
@@ -145,7 +143,6 @@ public class ProjectRequest {
                 .description(updateDto.getDescription())
                 .detail(updateDto.getDetail())
                 .managementStep(Project.ManagementStep.valueOf(updateDto.getManagementStep()))
-                .progressStepId(updateDto.getProgressStepId())
                 .devOwner(devOwnerMember)
                 .customerOwner(customerOwnerMember)
                 .startAt(updateDto.getStartAt())

--- a/module-service/src/main/java/com/checkping/dto/project/ProjectResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/project/ProjectResponse.java
@@ -252,8 +252,6 @@ public class ProjectResponse {
         private String detail;
         @Schema(description = "프로젝트 관리 단계")
         private Project.ManagementStep managementStep;
-        @Schema(description = "프로젝트 현재 진행단계 아이디")
-        private Long progressStepId;
         @Schema(description = "프로젝트 시작 일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private Date startAt;

--- a/module-service/src/main/java/com/checkping/dto/project/ProjectResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/project/ProjectResponse.java
@@ -32,8 +32,6 @@ public class ProjectResponse {
         private String description;
         @Schema(description = "프로젝트 긴 설명")
         private String detail;
-        @Schema(description = "프로젝트 상태")
-        private Project.Status status;
         @Schema(description = "프로젝트 관리 단계")
         private Project.ManagementStep managementStep;
         @Schema(description = "프로젝트 등록 일시")
@@ -65,7 +63,6 @@ public class ProjectResponse {
                     .name(project.getName())
                     .description(project.getDescription())
                     .detail(project.getDetail())
-                    .status(project.getStatus())
                     .managementStep(project.getManagementStep())
                     .regAt(project.getRegAt())
                     .updateAt(project.getUpdateAt())
@@ -142,8 +139,6 @@ public class ProjectResponse {
         private String description;
         @Schema(description = "프로젝트 긴 설명")
         private String detail;
-        @Schema(description = "프로젝트 상태")
-        private Project.Status status;
         @Schema(description = "프로젝트 관리 단계")
         private Project.ManagementStep managementStep;
         @Schema(description = "프로젝트 등록 일시")
@@ -169,12 +164,11 @@ public class ProjectResponse {
         @Schema(description = "프로젝트 클릭 가능 여부")
         private Integer clickable;
 
-        public ProjectListDetailDto(long id, String name, String description, String detail, String status, String managementStep, Date regAt, Date updateAt, Date startAt, Date closeAt, String deletedYn, long devOwnerId, String developerName, String customerName, int clickable) {
+        public ProjectListDetailDto(long id, String name, String description, String detail, String managementStep, Date regAt, Date updateAt, Date startAt, Date closeAt, String deletedYn, long devOwnerId, String developerName, String customerName, int clickable) {
             this.id = id;
             this.name = name;
             this.description = description;
             this.detail = detail;
-            this.status = Project.Status.valueOf(status);
             this.managementStep = Project.ManagementStep.valueOf(managementStep);
             this.regAt = regAt;
             this.updateAt = updateAt;
@@ -256,8 +250,6 @@ public class ProjectResponse {
         private String description;
         @Schema(description = "프로젝트 긴 설명")
         private String detail;
-        @Schema(description = "프로젝트 상태")
-        private Project.Status status;
         @Schema(description = "프로젝트 관리 단계")
         private Project.ManagementStep managementStep;
         @Schema(description = "프로젝트 현재 진행단계 아이디")
@@ -285,7 +277,6 @@ public class ProjectResponse {
                     .name(detailsDto.getName())
                     .description(detailsDto.getDescription())
                     .detail(detailsDto.getDetail())
-                    .status(Project.Status.valueOf(detailsDto.getStatus()))
                     .managementStep(Project.ManagementStep.valueOf(detailsDto.getManagementStep()))
                     .progressStepId(detailsDto.getProgressStepId())
                     .startAt(detailsDto.getStartAt())

--- a/module-service/src/main/java/com/checkping/dto/project/ProjectResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/project/ProjectResponse.java
@@ -278,7 +278,6 @@ public class ProjectResponse {
                     .description(detailsDto.getDescription())
                     .detail(detailsDto.getDetail())
                     .managementStep(Project.ManagementStep.valueOf(detailsDto.getManagementStep()))
-                    .progressStepId(detailsDto.getProgressStepId())
                     .startAt(detailsDto.getStartAt())
                     .closeAt(detailsDto.getCloseAt())
                     .devOwnerId(detailsDto.getDevOwnerId())

--- a/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
@@ -15,7 +15,6 @@ import com.checkping.infra.repository.member.MemberRepository;
 import com.checkping.infra.repository.member.OrganizationRepository;
 import com.checkping.infra.repository.project.ProgressStepRepository;
 import com.checkping.infra.dto.ProjectDetailsDto;
-import com.checkping.infra.repository.project.projection.ProjectInfoProjection;
 import com.checkping.infra.repository.project.ProjectRepository;
 import com.checkping.dto.project.ProjectRequest;
 
@@ -69,10 +68,6 @@ public class ProjectServiceImpl implements ProjectService {
 
         progressStepRepository.saveAll(steps);
 
-        Long firstStepId = steps.get(0).getId();
-
-        project.updateProgressStep(firstStepId);
-
         return ProjectResponse.ProjectDto.toDto(project);
     }
 
@@ -109,11 +104,11 @@ public class ProjectServiceImpl implements ProjectService {
 
 
     @Override
-    public ProjectResponse.ProjectListDto findAllProjects(String keyword, String status, int currentPage, int pageSize) {
+    public ProjectResponse.ProjectListDto findAllProjects(String keyword, String managementStep, int currentPage, int pageSize) {
         Pageable pageable = PageRequest.of(currentPage-1, pageSize, Sort.Direction.DESC, "id");
         Member member = currentMemberUtil.getCurrentMember();
 
-        Page<ProjectResponse.ProjectListDetailDto> results = getProjectListByRoleAndType(member, keyword, status, pageable);
+        Page<ProjectResponse.ProjectListDetailDto> results = getProjectListByRoleAndType(member, keyword, managementStep, pageable);
 
         return ProjectResponse.ProjectListDto.fromEntityPage(results);
     }
@@ -166,11 +161,11 @@ public class ProjectServiceImpl implements ProjectService {
                 .collect(Collectors.toList());
     }
 
-    private Page<ProjectResponse.ProjectListDetailDto> getProjectListByRoleAndType(Member member, String keyword, String status, Pageable pageable) {
+    private Page<ProjectResponse.ProjectListDetailDto> getProjectListByRoleAndType(Member member, String keyword, String managementStep, Pageable pageable) {
         Member.Role role = member.getRole();
 
         if (role.equals(Member.Role.ADMIN)) {
-            Page<Object[]> results = projectRepository.findAdminProjectsByKeywordAndStatus(keyword, status, pageable);
+            Page<Object[]> results = projectRepository.findAdminProjectsByKeywordAndManagementStep(keyword, managementStep, pageable);
             return toProjectListDetailDto(results);
         }
 
@@ -178,10 +173,10 @@ public class ProjectServiceImpl implements ProjectService {
         Long memberId = member.getId();
 
         if (type == Organization.Type.DEVELOPER) {
-            Page<Object[]> results = projectRepository.findDeveloperProjectsByKeywordAndStatus(keyword, status, pageable, memberId);
+            Page<Object[]> results = projectRepository.findDeveloperProjectsByKeywordAndManagementStep(keyword, managementStep, pageable, memberId);
             return toProjectListDetailDto(results);
         } else if (type == Organization.Type.CUSTOMER) {
-            Page<Object[]> results = projectRepository.findCustomerProjectsByKeywordAndStatus(keyword, status, pageable, memberId);
+            Page<Object[]> results = projectRepository.findCustomerProjectsByKeywordAndManagementStep(keyword, managementStep, pageable, memberId);
             return toProjectListDetailDto(results);
         }
 
@@ -194,17 +189,16 @@ public class ProjectServiceImpl implements ProjectService {
                 (String) row[1], // name
                 (String) row[2], // description
                 (String) row[3], // detail
-                (String) row[4], // status
-                (String) row[5], // managementStep
-                (Date) row[6], // regAt
-                (Date) row[7], // updateAt
-                (Date) row[8], // startAt
-                (Date) row[9], // closeAt
-                (String) row[10], // deletedYn
-                ((Number) row[11]).longValue(), // devOwnerId
-                (String) row[12], // developerName
-                (String) row[13], // customerName
-                ((Number) row[14]).intValue() // clickable
+                (String) row[4], // managementStep
+                (Date) row[5], // regAt
+                (Date) row[6], // updateAt
+                (Date) row[7], // startAt
+                (Date) row[8], // closeAt
+                (String) row[9], // deletedYn
+                ((Number) row[10]).longValue(), // devOwnerId
+                (String) row[11], // developerName
+                (String) row[12], // customerName
+                ((Number) row[13]).intValue() // clickable
         ));
     }
 

--- a/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
@@ -68,6 +68,10 @@ public class ProjectServiceImpl implements ProjectService {
 
         progressStepRepository.saveAll(steps);
 
+        Long firstStepId = steps.get(0).getId();
+
+        project.updateProgressStep(firstStepId);
+
         return ProjectResponse.ProjectDto.toDto(project);
     }
 


### PR DESCRIPTION
# 🚀 Pull Request

프로젝트 엔티티 status 제거

## #️⃣ 연관된 이슈

#389 

## 📋 작업 내용

project 엔티티 status 제거로 인한 수정
- dto에서 status 제거
- 목록 조회 api의 검색 조건 status -> management_step
- status 별 프로젝트 조회 api 제거

ProjectInfoProjection 삭제
- 기존 status 별 프로젝트 조회 시 사용했던 projection 삭제

progress_step_id 부분 수정
- reqeust, response dto에서 제거 (프로젝트 생성 시 service단에서 추가만 해줌)
- 프로젝트 업데이트 코드에서 제거 (progress_step_id 업데이트는 결재 시에만)