### PR TITLE
Feature/411 feature 프로젝트 별 정보 조회 시 관리단계 결재자 정보 조회

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/ProjectApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/ProjectApi.java
@@ -47,7 +47,7 @@ public interface ProjectApi {
     BaseResponse<ProjectResponse.ProjectManagementStepCountDto> countProjectsByManagementStep();
 
     @Operation(summary = "프로젝트 별 정보 조회", description = "프로젝트의 기본 정보를 조회하는 기능입니다.")
-    BaseResponse<ProjectResponse.ProjectDetailDto> getProject(
+    BaseResponse<ProjectResponse.ProjectInfoDto> getProject(
             @Parameter(description = "프로젝트 ID") Long projectId
     );
 

--- a/module-api/src/main/java/com/checkping/api/controller/ProjectController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/ProjectController.java
@@ -84,8 +84,8 @@ public class ProjectController implements ProjectApi {
 
     @Override
     @GetMapping(value = {"/admins/projects/{projectId}/project-info", "/projects/{projectId}/project-info"})
-    public BaseResponse<ProjectResponse.ProjectDetailDto> getProject(@PathVariable Long projectId) {
-        ProjectResponse.ProjectDetailDto project = projectService.findProjectByProjectId(projectId);
+    public BaseResponse<ProjectResponse.ProjectInfoDto> getProject(@PathVariable Long projectId) {
+        ProjectResponse.ProjectInfoDto project = projectService.findProjectByProjectId(projectId);
         return BaseResponse.success(project);
     }
 

--- a/module-domain/src/main/java/com/checkping/domain/project/projection/OwnerInfo.java
+++ b/module-domain/src/main/java/com/checkping/domain/project/projection/OwnerInfo.java
@@ -1,0 +1,24 @@
+package com.checkping.domain.project.projection;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class OwnerInfo {
+    private String ownerOrgName;
+    private String ownerName;
+    private String profileImageUrl;
+    private String jobRole;
+    private String jobTitle;
+    private String phoneNum;
+
+    @QueryProjection
+    public OwnerInfo(String ownerOrgName, String ownerName, String profileImageUrl, String jobRole, String jobTitle, String phoneNum) {
+        this.ownerOrgName = ownerOrgName;
+        this.ownerName = ownerName;
+        this.profileImageUrl = profileImageUrl;
+        this.jobRole = jobRole;
+        this.jobTitle = jobTitle;
+        this.phoneNum = phoneNum;
+    }
+}

--- a/module-domain/src/main/java/com/checkping/domain/project/projection/ProjectInfo.java
+++ b/module-domain/src/main/java/com/checkping/domain/project/projection/ProjectInfo.java
@@ -1,0 +1,31 @@
+package com.checkping.domain.project.projection;
+
+import com.checkping.domain.project.Project;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ProjectInfo {
+    private Long id;
+    private String projectName;
+    private String description;
+    private Project.ManagementStep managementStep;
+    private Long developerOwnerId;
+    private Long customerOwnerId;
+    private LocalDateTime startAt;
+    private LocalDateTime closeAt;
+
+    @QueryProjection
+    public ProjectInfo(Long id, String projectName, String description, Project.ManagementStep managementStep, Long developerOwnerId, Long customerOwnerId, LocalDateTime startAt, LocalDateTime closeAt) {
+        this.id = id;
+        this.projectName = projectName;
+        this.description = description;
+        this.managementStep = managementStep;
+        this.developerOwnerId = developerOwnerId;
+        this.customerOwnerId = customerOwnerId;
+        this.startAt = startAt;
+        this.closeAt = closeAt;
+    }
+}

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectRepository.java
@@ -88,24 +88,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
             "AND m.id = :memberId ", nativeQuery = true)
     Page<Object[]> findCustomerProjectsByKeywordAndManagementStep(@Param("keyword") String keyword, @Param("managementStep") String managementStep, @Param("pageable") Pageable pageable, @Param("memberId") Long memberId);
 
-    @Query(value = "SELECT " +
-            "    p.id, " +
-            "    p.name AS project_name, " +
-            "    p.description, " +
-            "    o.name AS dev_org_name, " +
-            "    m.profile_image_url, " +
-            "    m.name AS member_name, " +
-            "    m.job_role, " +
-            "    m.job_title, " +
-            "    m.phone_num, " +
-            "    p.start_at, " +
-            "    p.close_at " +
-            "FROM project p " +
-            "LEFT JOIN member m ON p.dev_owner_id = m.id " +
-            "LEFT JOIN organization o ON m.org_id = o.id " +
-            "WHERE p.id = :projectId", nativeQuery = true)
-    Optional<ProjectDetailsDto> findProjectById(@Param("projectId") Long projectId);
-
     @Query(value = "SELECT p.id, p.name, p.description, p.detail, p.management_step, p.start_at, p.close_at, p.dev_owner_id, " +
             "org_info.developer_org_id, " +
             "org_info.customer_org_id " +

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/querydsl/ProjectRepositoryCustom.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/querydsl/ProjectRepositoryCustom.java
@@ -1,11 +1,14 @@
 package com.checkping.infra.repository.project.querydsl;
 
+import com.checkping.domain.project.projection.OwnerInfo;
 import com.checkping.domain.project.projection.ProjectCountByManagementStep;
+import com.checkping.domain.project.projection.ProjectInfo;
 import com.checkping.domain.project.projection.ProjectListInfoByManagementStep;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProjectRepositoryCustom {
     List<ProjectCountByManagementStep> countProjectsByManagementStep(Long orgId, Long memberId);
@@ -13,4 +16,8 @@ public interface ProjectRepositoryCustom {
     Page<ProjectListInfoByManagementStep> findProjectsByManagementSteps(Long orgId, Long memberId, String manageStep, Pageable pageable);
 
     List<Long> memberByProject(Long memberId, Pageable pageable);
+
+    Optional<ProjectInfo> findProjectInfoById(Long id);
+
+    Optional<OwnerInfo> findOwnerMemberInfoById(Long memberId);
 }

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/querydsl/ProjectRepositoryImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/querydsl/ProjectRepositoryImpl.java
@@ -1,16 +1,16 @@
 package com.checkping.infra.repository.project.querydsl;
 
+import com.checkping.domain.member.QMember;
+import com.checkping.domain.member.QOrganization;
 import com.checkping.domain.permission.QMemberByProject;
 import com.checkping.domain.permission.QOrganizationByProject;
 import com.checkping.domain.project.Project;
 
 import com.checkping.domain.project.QProject;
-import com.checkping.domain.project.projection.ProjectCountByManagementStep;
-import com.checkping.domain.project.projection.ProjectListInfoByManagementStep;
-import com.checkping.domain.project.projection.QProjectCountByManagementStep;
-import com.checkping.domain.project.projection.QProjectListInfoByManagementStep;
+import com.checkping.domain.project.projection.*;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Page;
@@ -18,6 +18,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
 public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 
@@ -100,6 +101,47 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
         return query.fetch();
+    }
+
+    @Override
+    public Optional<ProjectInfo> findProjectInfoById(Long projectId) {
+        QProject project = QProject.project;
+
+        ProjectInfo projectInfo = queryFactory
+                .select(Projections.constructor(ProjectInfo.class,
+                        project.id,
+                        project.name.as("projectName"),
+                        project.description,
+                        project.managementStep,
+                        project.devOwner.id.as("developerOwnerId"),
+                        project.customerOwner.id.as("customerOwnerId"),
+                        project.startAt,
+                        project.closeAt))
+                .from(project)
+                .where(project.id.eq(projectId))
+                .fetchOne();
+
+        return Optional.ofNullable(projectInfo);
+    }
+
+    public Optional<OwnerInfo> findOwnerMemberInfoById(Long memberId) {
+        QMember member = QMember.member;
+        QOrganization organization = QOrganization.organization;
+
+        OwnerInfo ownerInfo = queryFactory
+                .select(Projections.constructor(OwnerInfo.class,
+                        organization.name.as("ownerOrgName"),
+                        member.name.as("ownerName"),
+                        member.profileImageUrl,
+                        member.jobRole,
+                        member.jobTitle,
+                        member.phoneNum))
+                .from(member)
+                .leftJoin(organization).on(member.organization.id.eq(organization.id))
+                .where(member.id.eq(memberId))
+                .fetchOne();
+
+        return Optional.ofNullable(ownerInfo);
     }
 
 }

--- a/module-service/src/main/java/com/checkping/dto/project/ProjectResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/project/ProjectResponse.java
@@ -4,8 +4,8 @@ package com.checkping.dto.project;
 import com.checkping.common.dto.PageMetaResponse;
 import com.checkping.common.utils.DateTimeUtils;
 import com.checkping.domain.project.Project;
-import com.checkping.infra.dto.ProjectDetailsDto;
-import com.checkping.infra.dto.ProjectListDetailsDto;
+import com.checkping.domain.project.projection.OwnerInfo;
+import com.checkping.domain.project.projection.ProjectInfo;
 import com.checkping.infra.dto.ProjectUpdateDetailsDto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -83,45 +83,66 @@ public class ProjectResponse {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ProjectDetailDto {
+    public static class ProjectInfoDto {
         @Schema(description = "프로젝트 아이디")
         private Long id;
         @Schema(description = "프로젝트 이름")
         private String projectName;
         @Schema(description = "프로젝트 짧은 설명")
         private String description;
+        @Schema(description = "프로젝트 관리단계")
+        private Project.ManagementStep managementStep;
         @Schema(description = "개발사 이름")
-        private String devOrgName;
-        @Schema(description = "개발사 대표자 프로필 이미지 url")
-        private String profileImageUrl;
+        private String developerOrgName;
         @Schema(description = "개발사 대표자 이름")
-        private String memberName;
+        private String developerOwnerName;
+        @Schema(description = "개발사 대표자 프로필 이미지 url")
+        private String developerProfileImageUrl;
         @Schema(description = "개발사 대표자 직무")
-        private String jobRole;
+        private String developerJobRole;
         @Schema(description = "개발사 대표자 직급")
-        private String jobTitle;
+        private String developerJobTitle;
         @Schema(description = "개발사 대표자 연락처")
-        private String phoneNum;
+        private String developerPhoneNum;
+        @Schema(description = "고객사 이름")
+        private String customerOrgName;
+        @Schema(description = "고객사 대표자 이름")
+        private String customerOwnerName;
+        @Schema(description = "고객사 대표자 프로필 이미지 url")
+        private String customerProfileImageUrl;
+        @Schema(description = "고객사 대표자 직무")
+        private String customerJobRole;
+        @Schema(description = "고객사 대표자 직급")
+        private String customerJobTitle;
+        @Schema(description = "고객사 대표자 연락처")
+        private String customerPhoneNum;
         @Schema(description = "프로젝트 시작 일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        private Date startAt;
+        private LocalDateTime startAt;
         @Schema(description = "프로젝트 마감 일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        private Date closeAt;
+        private LocalDateTime closeAt;
 
-        public static ProjectDetailDto toDetailDto(ProjectDetailsDto detailsDto) {
-            return ProjectDetailDto.builder()
-                    .id(detailsDto.getId())
-                    .projectName(detailsDto.getProjectName())
-                    .description(detailsDto.getDescription())
-                    .devOrgName(detailsDto.getDevOrgName())
-                    .profileImageUrl(detailsDto.getProfileImageUrl())
-                    .memberName(detailsDto.getMemberName())
-                    .jobRole(detailsDto.getJobRole())
-                    .jobTitle(detailsDto.getJobTitle())
-                    .phoneNum(detailsDto.getPhoneNum())
-                    .startAt(detailsDto.getStartAt())
-                    .closeAt(detailsDto.getCloseAt())
+        public static ProjectInfoDto toDto(ProjectInfo projectInfo, OwnerInfo developerOwnerInfo, OwnerInfo customerOwnerInfo) {
+            return ProjectInfoDto.builder()
+                    .id(projectInfo.getId())
+                    .projectName(projectInfo.getProjectName())
+                    .description(projectInfo.getDescription())
+                    .managementStep(projectInfo.getManagementStep())
+                    .developerOrgName(developerOwnerInfo.getOwnerOrgName())
+                    .developerOwnerName(developerOwnerInfo.getOwnerName())
+                    .developerProfileImageUrl(developerOwnerInfo.getProfileImageUrl())
+                    .developerJobRole(developerOwnerInfo.getJobRole())
+                    .developerJobTitle(developerOwnerInfo.getJobTitle())
+                    .developerPhoneNum(developerOwnerInfo.getPhoneNum())
+                    .customerOrgName(customerOwnerInfo.getOwnerOrgName())
+                    .customerOwnerName(customerOwnerInfo.getOwnerName())
+                    .customerProfileImageUrl(customerOwnerInfo.getProfileImageUrl())
+                    .customerJobRole(customerOwnerInfo.getJobRole())
+                    .customerJobTitle(customerOwnerInfo.getJobTitle())
+                    .customerPhoneNum(customerOwnerInfo.getPhoneNum())
+                    .startAt(projectInfo.getStartAt())
+                    .closeAt(projectInfo.getCloseAt())
                     .build();
         }
     }
@@ -200,29 +221,6 @@ public class ProjectResponse {
             Map<String, Object> result = meta.toMap();
 
             return new ProjectListDto(projectDtos, result);
-        }
-    }
-
-    @Getter
-    @ToString
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class ProjectInfoDto {
-        @Schema(description = "프로젝트 아이디")
-        private Long id;
-        @Schema(description = "프로젝트 이름")
-        private String projectName;
-    }
-
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class ProjectInfoListDto {
-        private Map<String, List<ProjectInfoDto>> projectInfoMap;
-
-        public static ProjectInfoListDto infoListDto(Map<String, List<ProjectInfoDto>> projectInfoMap) {
-            return new ProjectInfoListDto(projectInfoMap);
         }
     }
 

--- a/module-service/src/main/java/com/checkping/service/project/ProjectService.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectService.java
@@ -17,7 +17,7 @@ public interface ProjectService {
 
     ProjectResponse.ProjectManagementStepCountDto countProjectsByManagementStep();
 
-    ProjectResponse.ProjectDetailDto findProjectByProjectId(Long projectId);
+    ProjectResponse.ProjectInfoDto findProjectByProjectId(Long projectId);
 
     ProjectResponse.ProjectListByManagementStepDto findProjectsByManagementSteps(String managementStep, int currentPage, int pageSize);
 }

--- a/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
@@ -6,15 +6,15 @@ import com.checkping.domain.member.Member;
 import com.checkping.domain.member.Organization;
 import com.checkping.domain.project.ProgressStep;
 import com.checkping.domain.project.Project;
+import com.checkping.domain.project.projection.OwnerInfo;
 import com.checkping.domain.project.projection.ProjectCountByManagementStep;
+import com.checkping.domain.project.projection.ProjectInfo;
 import com.checkping.domain.project.projection.ProjectListInfoByManagementStep;
 import com.checkping.dto.project.ProjectResponse;
-import com.checkping.infra.dto.ProjectListDetailsDto;
 import com.checkping.infra.dto.ProjectUpdateDetailsDto;
 import com.checkping.infra.repository.member.MemberRepository;
 import com.checkping.infra.repository.member.OrganizationRepository;
 import com.checkping.infra.repository.project.ProgressStepRepository;
-import com.checkping.infra.dto.ProjectDetailsDto;
 import com.checkping.infra.repository.project.ProjectRepository;
 import com.checkping.dto.project.ProjectRequest;
 
@@ -134,10 +134,15 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
-    public ProjectResponse.ProjectDetailDto findProjectByProjectId(Long projectId) {
-        ProjectDetailsDto detailsDto = projectRepository.findProjectById(projectId)
+    public ProjectResponse.ProjectInfoDto findProjectByProjectId(Long projectId) {
+        ProjectInfo projectInfo = projectRepository.findProjectInfoById(projectId)
                 .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND));
-        return ProjectResponse.ProjectDetailDto.toDetailDto(detailsDto);
+        OwnerInfo developerOwnerInfo = projectRepository.findOwnerMemberInfoById(projectInfo.getDeveloperOwnerId())
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND));
+        OwnerInfo customerOwnerInfo = projectRepository.findOwnerMemberInfoById(projectInfo.getCustomerOwnerId())
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND));
+
+        return ProjectResponse.ProjectInfoDto.toDto(projectInfo, developerOwnerInfo, customerOwnerInfo);
     }
 
     public ProjectResponse.ProjectUpdateDto getUpdateProjectInfo(Long projectId) {


### PR DESCRIPTION
# 🚀 Pull Request

프로젝트 별 정보 조회 시 관리단계, 결재자 정보 조회

## #️⃣ 연관된 이슈

#411 

## 📋 작업 내용

QueryDsl 코드 작성
- ProjectInfo, OwnerInfo 프로젝션 생성
- 프로젝트와 담당자 정보를 따로 조회
- 기존 findProjectById 메서드 제거

controller, service, response 추가
- 따로 조회한 데이터 dto로 변환하여 반환

