### PR TITLE
Feature/398 feature 프로젝트 진행 단계 엔티티 변경

### DIFF
--- a/module-domain/src/main/java/com/checkping/domain/project/ProgressStep.java
+++ b/module-domain/src/main/java/com/checkping/domain/project/ProgressStep.java
@@ -81,25 +81,30 @@ public class ProgressStep extends BaseEntity {
     @Getter
     @RequiredArgsConstructor
     public enum CurrentStep {
-        REQUIREMENTS("요구사항 정의"), SCREEN_DESIGN("화면설계"), DESIGN("디자인"), PUBLISHING(
-            "퍼블리싱"), DEVELOPMENT("개발"), REVIEW("검수");
+        REQUIREMENTS(1, "요구사항 정의", "요구사항을 수집하고 문서화하는 단계"),
+        SCREEN_DESIGN(2, "화면설계", "화면의 구조와 흐름을 정의하는 단계"),
+        DESIGN(3, "디자인", "UI/UX 디자인을 수행하는 단계"),
+        PUBLISHING(4, "퍼블리싱", "디자인을 웹 표준에 맞춰 적용하는 단계"),
+        DEVELOPMENT(5, "개발", "기능을 구현하고 시스템을 개발하는 단계"),
+        REVIEW(6, "검수", "완성된 결과물을 테스트하고 검수하는 단계");
 
+        private final Integer order;
+        private final String name;
         private final String description;
     }
 
     /**
      * 생성 팩토리 메서드
      *
-     * @param projectId         프로젝트 아이디
-     * @param relatedApprovalId 관련 결재 아이디
-     * @param name              단계명
-     * @param description       단계 설명
-     * @param stepOrder         순서
+     * @param projectId   프로젝트 아이디
+     * @param name        단계명
+     * @param description 단계 설명
+     * @param stepOrder   순서
      * @return ProgressStep Entity
      */
-    public static ProgressStep generate(Long projectId, Long relatedApprovalId, String name,
-        String description, Integer stepOrder) {
-        return ProgressStep.builder().projectId(projectId).relatedApprovalId(relatedApprovalId)
-            .name(name).description(description).stepOrder(stepOrder).status(Status.WAIT).build();
+    public static ProgressStep generate(Long projectId, String name, String description,
+        Integer stepOrder) {
+        return ProgressStep.builder().projectId(projectId).name(name).description(description)
+            .stepOrder(stepOrder).status(Status.WAIT).build();
     }
 }

--- a/module-domain/src/main/java/com/checkping/domain/project/ProgressStep.java
+++ b/module-domain/src/main/java/com/checkping/domain/project/ProgressStep.java
@@ -2,10 +2,20 @@ package com.checkping.domain.project;
 
 
 import com.checkping.domain.BaseEntity;
-import jakarta.persistence.*;
-import lombok.*;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
@@ -18,11 +28,13 @@ public class ProgressStep extends BaseEntity {
     id : id
     name : 단계명
     description : 단계 설명
-    order : 순서
-    status : 단계 상태
+    stepOrder : 순서
+    status : 진행 단계 상태
     start_at : 시작 일시
     close_at : 마감 일시
+    deadline_at : 예상 마감 일시
     project : 프로젝트 (FK : project_id)
+    related_approval : 관련 결재 (FK : approval_id)
      */
 
     @Id
@@ -41,7 +53,7 @@ public class ProgressStep extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
-    private Project.Status status;
+    private Status status;
 
     @Column(name = "start_at")
     private LocalDateTime startAt;
@@ -49,29 +61,45 @@ public class ProgressStep extends BaseEntity {
     @Column(name = "close_at")
     private LocalDateTime closeAt;
 
+    @Column(name = "deadline_at")
+    private LocalDateTime deadlineAt;
+
     @Column(name = "project_id")
     private Long projectId;
 
-    /*@ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id")
-    private Project project;*/
+    @Column(name = "related_approval_id")
+    private Long relatedApprovalId;
 
     @Getter
     @RequiredArgsConstructor
-    public enum ProgressStatus {
-        NOT_STARTED, IN_PROGRESS, COMPLETED, CANCELED
+    public enum Status {
+        WAIT("대기"), IN_PROGRESS("진행중"), PAUSED("일시 중단"), COMPLETED("완료");
+
+        private final String description;
     }
 
     @Getter
     @RequiredArgsConstructor
     public enum CurrentStep {
-        REQUIREMENTS("요구사항 정의"),
-        SCREEN_DESIGN("화면설계"),
-        DESIGN( "디자인" ),
-        PUBLISHING("퍼블리싱"),
-        DEVELOPMENT("개발"),
-        REVIEW("검수");
+        REQUIREMENTS("요구사항 정의"), SCREEN_DESIGN("화면설계"), DESIGN("디자인"), PUBLISHING(
+            "퍼블리싱"), DEVELOPMENT("개발"), REVIEW("검수");
 
         private final String description;
+    }
+
+    /**
+     * 생성 팩토리 메서드
+     *
+     * @param projectId         프로젝트 아이디
+     * @param relatedApprovalId 관련 결재 아이디
+     * @param name              단계명
+     * @param description       단계 설명
+     * @param stepOrder         순서
+     * @return ProgressStep Entity
+     */
+    public static ProgressStep generate(Long projectId, Long relatedApprovalId, String name,
+        String description, Integer stepOrder) {
+        return ProgressStep.builder().projectId(projectId).relatedApprovalId(relatedApprovalId)
+            .name(name).description(description).stepOrder(stepOrder).status(Status.WAIT).build();
     }
 }

--- a/module-service/src/main/java/com/checkping/dto/project/ProgressStepGet.java
+++ b/module-service/src/main/java/com/checkping/dto/project/ProgressStepGet.java
@@ -22,7 +22,9 @@ public class ProgressStepGet {
         status : 단계 상태
         startAt : 시작 일시
         closeAt : 마감 일시
+        deadlineAt : 예상 마감 일시
         projectId : 프로젝트 ID
+        relatedApprovalId : 관련 결재 ID
          */
         @Schema(description = "진행 단계 ID")
         private Long id;
@@ -38,8 +40,12 @@ public class ProgressStepGet {
         private String startAt;
         @Schema(description = "마감 일시")
         private String closeAt;
+        @Schema(description = "예상 마감 일시")
+        private String deadlineAt;
         @Schema(description = "프로젝트 ID")
         private Long projectId;
+        @Schema(description = "관련 결재 ID")
+        private Long relatedApprovalId;
 
         /**
          * ProgressStep Entity -> ProgressStepGet.Response Dto
@@ -53,11 +59,12 @@ public class ProgressStepGet {
             response.name = progressStep.getName();
             response.description = progressStep.getDescription();
             response.stepOrder = progressStep.getStepOrder();
-            response.status =
-                progressStep.getStatus() != null ? progressStep.getStatus().name() : null;
+            response.status = progressStep.getStatus().name();
             response.startAt = DateTimeUtils.format(progressStep.getStartAt());
             response.closeAt = DateTimeUtils.format(progressStep.getCloseAt());
+            response.deadlineAt = DateTimeUtils.format(progressStep.getDeadlineAt());
             response.projectId = progressStep.getProjectId();
+            response.relatedApprovalId = progressStep.getRelatedApprovalId();
             return response;
         }
 

--- a/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
@@ -58,11 +58,8 @@ public class ProjectServiceImpl implements ProjectService {
         List<ProgressStep> steps = new ArrayList<>();
 
         for (ProgressStep.CurrentStep step : ProgressStep.CurrentStep.values()) {
-            ProgressStep progressStep = ProgressStep.builder()
-                    .projectId(project.getId())
-                    .name(step.getDescription())
-                    .build();
-
+            // generate progress step
+            ProgressStep progressStep = ProgressStep.generate(project.getId(),step.getName(),step.getDescription(), step.getOrder());
             steps.add(progressStep);
         }
 


### PR DESCRIPTION
# 🚀 Pull Request

**[프로젝트 진행 단계 엔티티 변경]**

## #️⃣ 연관된 이슈

- #398 

## 📋 작업 내용

1. 예상 마감 일시 추가 (deadline_at)
2. 프로젝트 진행 단계 상태 참조 타입 변경 (프로젝트 진행 단계에 대한 상태)
-> 해당 부분은 프로젝트 엔티티에서 참조하고 있는 것을 프로젝트 진행 단계 엔티티에서 관리하도록 변경하였습니다.
이 컬럼은 프로젝트 진행 단계 자체가 어떻게 진행하고 있는지 상태를 확인할 필요가 있다고 판단하여 그대로 두었습니다.
3. 프로젝트 진행 단계 완료 시에 관련한 결재를 입력해야 할 필요가 있을 것 같아서 연관관계를 추가하였습니다.
-> 기존 프로젝트 진행 단계 엔티티가 연관관계 맵핑을 사용하지 않고 있어서 같이 사용하지 않았습니다.
4. 프로젝트 진행 단계 생성 팩토리 메서드를 만들었습니다.
5. 프로젝트 생성 시 기본 진행단계 셋팅
6. 프로젝트 진행 단계 DB 수정 및 마이그레이션 완료
