### PR TITLE
Feature/327 Redis 연결 체크 로직 개선 및 JWT 예외 처리 개선

### DIFF
--- a/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
@@ -71,9 +71,6 @@ public class JWTFilter extends OncePerRequestFilter {
                     ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
                     return;
                 }
-            } else {
-                // Redis 연결 불가능 시 로그만 남기고 스킵
-                System.out.println("[JWTFilter] Redis not available -> Skip blacklist check");
             }
 
             // 사용자 정보 추출
@@ -98,8 +95,8 @@ public class JWTFilter extends OncePerRequestFilter {
             ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
             return;
         } catch (Exception e) {
-            System.out.println(e.getMessage());
-            ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "Invalid token");
+            BaseResponse<Void> errorResponse = BaseResponse.fail(ErrorCode.UNAUTHORIZED);
+            ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
             return;
         }
 

--- a/module-service/src/main/java/com/checkping/service/member/auth/TokenBlacklistService.java
+++ b/module-service/src/main/java/com/checkping/service/member/auth/TokenBlacklistService.java
@@ -3,7 +3,7 @@ package com.checkping.service.member.auth;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 @Service
 public class TokenBlacklistService {
@@ -15,12 +15,27 @@ public class TokenBlacklistService {
     }
 
     // Redis 연결 가능 여부 체크 메서드
+
     public boolean isRedisAvailable() {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Boolean> future = executor.submit(() -> {
+            try {
+                String pong = redisTemplate.getConnectionFactory().getConnection().ping();
+                return "PONG".equalsIgnoreCase(pong);
+            } catch (Exception e) {
+                return false;
+            }
+        });
+
         try {
-            String pong = redisTemplate.getConnectionFactory().getConnection().ping();
-            return "PONG".equalsIgnoreCase(pong);
+            return future.get(500, TimeUnit.MILLISECONDS); // 0.1초 이상 걸리면 false 반환
+        } catch (TimeoutException e) {
+            System.out.println("[JWTFilter] Redis connection timeout -> Skip blacklist check");
+            return false;
         } catch (Exception e) {
             return false;
+        } finally {
+            executor.shutdown();
         }
     }
 


### PR DESCRIPTION
# 🚀 Pull Request

- Redis 연결 체크 로직 개선 
- JWTFilter에서 검증 예외 처리 로직 개선
  - 모든 예외를 동일한 응답 형식(`BaseResponse.fail`)으로 처리

## #️⃣ 연관된 이슈

#327

## 📋 작업 내용
- Redis 연결 확인 시 ExecutorService를 활용하여 별도의 스레드에서 실행하도록 변경
- 연결 검사 시 500ms 초과하면 TimeoutException을 발생시키고 블랙리스트 검사를 건너뜀
- 로컬 테스트 환경에서 Redis 연결확인에 시간 지연 방지하도록 개선
- Timeout 발생 시 콘솔에 경고 메시지 출력 "[JWTFilter] Redis connection timeout -> Skip blacklist check"
- JWT 검증 과정에서 발생하는 일반적인 예외 처리 수정
- 예외 발생 시 `System.out.println(e.getMessage())` 대신 `BaseResponse.fail(ErrorCode.UNAUTHORIZED)`를 반환하도록 변경
- 모든 예외를 동일한 응답 형식 반환
