### PR TITLE
feature/410 feature 프로젝트 관리단계 수정 api 생성

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/ProjectApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/ProjectApi.java
@@ -62,4 +62,10 @@ public interface ProjectApi {
     BaseResponse<List<ProgressStepGet.Response>> getProgressStep(
             @Parameter(description = "프로젝트 ID") Long projectId
     );
+
+    @Operation(summary = "프로젝트 관리단계 수정", description = "프로젝트 관리단계를 수정하는 기능입니다.")
+    BaseResponse<ProjectResponse.ProjectDto> updateProjectsByManagementSteps(
+            @Parameter(description = "프로젝트 ID") Long projectId,
+            @Parameter(description = "프로젝트 관리단계") String managementStep
+    );
 }

--- a/module-api/src/main/java/com/checkping/api/controller/ProjectController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/ProjectController.java
@@ -10,14 +10,7 @@ import com.checkping.service.project.progressstep.ProgressStepService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -97,6 +90,14 @@ public class ProjectController implements ProjectApi {
             @RequestParam(defaultValue = "10") int pageSize) {
         ProjectResponse.ProjectListByManagementStepDto projectList = projectService.findProjectsByManagementSteps(managementStep, currentPage, pageSize);
         return BaseResponse.success(projectList);
+    }
+
+    @PutMapping("/projects/{projectId}/management-steps")
+    public BaseResponse<ProjectResponse.ProjectDto> updateProjectsByManagementSteps(
+            @PathVariable Long projectId,
+            @RequestParam String managementStep) {
+        ProjectResponse.ProjectDto project = projectService.updateManagementStep(projectId, managementStep);
+        return BaseResponse.success(project);
     }
 
     @Override

--- a/module-domain/src/main/java/com/checkping/domain/project/Project.java
+++ b/module-domain/src/main/java/com/checkping/domain/project/Project.java
@@ -31,6 +31,7 @@ public class Project extends BaseEntity {
     reg_at : 프로젝트 등록 일시
     update_at : 프로젝트 수정 일시
     start_at : 프로젝트 시작 일시
+    deadline_at : 프로젝트 예상 종료(마감) 일시
     close_at : 프로젝트 종료(마감) 일시
     resister_id : 등록자 아이디
     updater_id : 수정자 아이디
@@ -74,6 +75,9 @@ public class Project extends BaseEntity {
 
     @Column(name = "start_at")
     private LocalDateTime startAt;
+
+    @Column(name = "deadline_at")
+    private LocalDateTime deadlineAt;
 
     @Column(name = "close_at")
     private LocalDateTime closeAt;
@@ -137,4 +141,11 @@ public class Project extends BaseEntity {
         this.managementStep = ManagementStep.DELETED;
     }
 
+    public void updateManagementStep(Project.ManagementStep managementStep){
+        this.managementStep = managementStep;
+    }
+
+    public void updateCloseAt(){
+        this.closeAt = LocalDateTime.now();
+    }
 }

--- a/module-domain/src/main/java/com/checkping/domain/project/projection/ProjectInfo.java
+++ b/module-domain/src/main/java/com/checkping/domain/project/projection/ProjectInfo.java
@@ -15,10 +15,11 @@ public class ProjectInfo {
     private Long developerOwnerId;
     private Long customerOwnerId;
     private LocalDateTime startAt;
+    private LocalDateTime deadlineAt;
     private LocalDateTime closeAt;
 
     @QueryProjection
-    public ProjectInfo(Long id, String projectName, String description, Project.ManagementStep managementStep, Long developerOwnerId, Long customerOwnerId, LocalDateTime startAt, LocalDateTime closeAt) {
+    public ProjectInfo(Long id, String projectName, String description, Project.ManagementStep managementStep, Long developerOwnerId, Long customerOwnerId, LocalDateTime startAt, LocalDateTime deadlineAt, LocalDateTime closeAt) {
         this.id = id;
         this.projectName = projectName;
         this.description = description;
@@ -26,6 +27,7 @@ public class ProjectInfo {
         this.developerOwnerId = developerOwnerId;
         this.customerOwnerId = customerOwnerId;
         this.startAt = startAt;
+        this.deadlineAt = deadlineAt;
         this.closeAt = closeAt;
     }
 }

--- a/module-infra/src/main/java/com/checkping/infra/dto/ProjectUpdateDetailsDto.java
+++ b/module-infra/src/main/java/com/checkping/infra/dto/ProjectUpdateDetailsDto.java
@@ -16,6 +16,7 @@ public class ProjectUpdateDetailsDto {
     private final String detail;
     private final String managementStep;
     private final Date startAt;
+    private final Date deadlineAt;
     private final Date closeAt;
     private final Long devOwnerId;
     private final Long developerOrgId;

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/ProjectRepository.java
@@ -1,7 +1,6 @@
 package com.checkping.infra.repository.project;
 
 import com.checkping.domain.project.Project;
-import com.checkping.infra.dto.ProjectDetailsDto;
 import com.checkping.infra.dto.ProjectUpdateDetailsDto;
 import com.checkping.infra.repository.project.querydsl.ProjectRepositoryCustom;
 import org.springframework.data.domain.Page;
@@ -18,7 +17,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
     @Query(value =
             "SELECT " +
             "p.id, p.name, p.description, p.detail, p.management_step, " +
-            "p.reg_at, p.update_at, p.start_at, p.close_at, p.deleted_yn, p.dev_owner_id, " +
+            "p.reg_at, p.update_at, p.start_at, p.deadline_at, p.close_at, p.deleted_yn, p.dev_owner_id, " +
             "org_info.developer_name, org_info.customer_name, 1 AS clickable " +
             "FROM project p " +
             "LEFT JOIN ( " +
@@ -36,7 +35,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
     @Query(value =
             "SELECT " +
             "p.id, p.name, p.description, p.detail, p.management_step, " +
-            "p.reg_at, p.update_at, p.start_at, p.close_at, p.deleted_yn, p.dev_owner_id, " +
+            "p.reg_at, p.update_at, p.start_at, p.deadline_at, p.close_at, p.deleted_yn, p.dev_owner_id, " +
             "org_info.developer_name, org_info.customer_name, " +
             "(SELECT CASE WHEN EXISTS (SELECT 1 FROM member_by_project mbp WHERE mbp.project_id=p.id AND mbp.member_id=m.id) THEN 1 ELSE 0 END) AS clickable " +
             "FROM project p " +
@@ -69,7 +68,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
     @Query(value =
             "SELECT " +
             "p.id, p.name, p.description, p.detail, p.management_step, " +
-            "p.reg_at, p.update_at, p.start_at, p.close_at, p.deleted_yn, p.dev_owner_id, " +
+            "p.reg_at, p.update_at, p.start_at, p.deadline_at, p.close_at, p.deleted_yn, p.dev_owner_id, " +
             "org_info.developer_name, org_info.customer_name, 1 AS clickable " +
             "FROM project p " +
             "LEFT JOIN member_by_project mbp ON p.id = mbp.project_id " +
@@ -88,7 +87,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
             "AND m.id = :memberId ", nativeQuery = true)
     Page<Object[]> findCustomerProjectsByKeywordAndManagementStep(@Param("keyword") String keyword, @Param("managementStep") String managementStep, @Param("pageable") Pageable pageable, @Param("memberId") Long memberId);
 
-    @Query(value = "SELECT p.id, p.name, p.description, p.detail, p.management_step, p.start_at, p.close_at, p.dev_owner_id, " +
+    @Query(value = "SELECT p.id, p.name, p.description, p.detail, p.management_step, p.start_at, p.deadline_at, p.close_at, p.dev_owner_id, " +
             "org_info.developer_org_id, " +
             "org_info.customer_org_id " +
             "FROM project p " +

--- a/module-infra/src/main/java/com/checkping/infra/repository/project/querydsl/ProjectRepositoryImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/project/querydsl/ProjectRepositoryImpl.java
@@ -116,6 +116,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
                         project.devOwner.id.as("developerOwnerId"),
                         project.customerOwner.id.as("customerOwnerId"),
                         project.startAt,
+                        project.deadlineAt,
                         project.closeAt))
                 .from(project)
                 .where(project.id.eq(projectId))

--- a/module-infra/src/test/java/com/checkping/infra/ProjectRepositoryTests.java
+++ b/module-infra/src/test/java/com/checkping/infra/ProjectRepositoryTests.java
@@ -23,7 +23,6 @@ public class ProjectRepositoryTests {
                     .name("이름" + Integer.toString(i))
                     .description("설명")
                     .detail("상세설명")
-                    .status(Project.Status.IN_PROGRESS)
                     .regAt(LocalDateTime.now())
                     .closeAt(LocalDate.parse("2025-12-30").atStartOfDay())
                     .resisterId(49283L)

--- a/module-service/src/main/java/com/checkping/dto/project/ProjectRequest.java
+++ b/module-service/src/main/java/com/checkping/dto/project/ProjectRequest.java
@@ -29,7 +29,7 @@ public class ProjectRequest {
         detail : 프로젝트 세부 설명
         managementStep : 프로젝트 관리 단계 * CONTRACT(계약), IN_PROGRESS(진행중), COMPLETED(납품완료), MAINTENANCE(하자보수), PAUSED(일시중단)
         startAt : 프로젝트 시작 일시
-        closeAt : 프로젝트 종료 일시
+        deadlineAt : 프로젝트 예상 종료 일시
         resisterId : 등록자 아이디
         devOwnerId : 개발사 대표자 아이디
         customerOwnerId : 고객사 결재자 아이디
@@ -48,9 +48,9 @@ public class ProjectRequest {
         @Schema(description = "프로젝트 시작 일시", example = "2025-01-15 10:17:15", type = "string")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime startAt;
-        @Schema(description = "프로젝트 마감 일시", example = "2025-12-28 11:17:15", type = "string")
+        @Schema(description = "프로젝트 예상 종료 일시", example = "2025-12-28 10:10:15", type = "string")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        private LocalDateTime closeAt;
+        private LocalDateTime deadlineAt;
         @Schema(description = "개발사 대표자 아이디", example = "1")
         private Long devOwnerId;
         @Schema(description = "고객사 결재자 아이디", example = "1")
@@ -77,7 +77,7 @@ public class ProjectRequest {
                 .managementStep(Project.ManagementStep.valueOf(resisterDto.getManagementStep()))
                 .regAt(LocalDateTime.now())
                 .startAt(resisterDto.getStartAt())
-                .closeAt(resisterDto.getCloseAt())
+                .deadlineAt(resisterDto.getDeadlineAt())
                 .devOwner(devOwnerMember)
                 .customerOwner(customerOwnerMember)
                 .organizations(organizations)
@@ -97,7 +97,7 @@ public class ProjectRequest {
        detail : 프로젝트 세부 설명
        managementStep : 프로젝트 관리 단계 * CONTRACT(계약), IN_PROGRESS(진행중), COMPLETED(납품완료), MAINTENANCE(하자보수), PAUSED(일시중단)
        startAt : 프로젝트 시작 일시
-       closeAt : 프로젝트 종료 일시
+       deadlineAt : 프로젝트 예상 종료 일시
        devOwnerId : 개발사 대표자 아이디
        developerOrgId : 개발사 아이디
        customerOwnerId : 고객사 결재자 아이디
@@ -115,9 +115,9 @@ public class ProjectRequest {
         @Schema(description = "프로젝트 시작 일시", example = "2025-01-15 10:17:15", type = "string")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime startAt;
-        @Schema(description = "프로젝트 마감 일시", examples = "2025-12-28 11:17:15", type = "string")
+        @Schema(description = "프로젝트 예상 종료 일시", examples = "2025-12-28 10:10:15", type = "string")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        private LocalDateTime closeAt;
+        private LocalDateTime deadlineAt;
         @Schema(description = "개발사 대표자 아이디", example = "1")
         private Long devOwnerId;
         @Schema(description = "고객사 결재자 아이디", example = "1")
@@ -146,7 +146,7 @@ public class ProjectRequest {
                 .devOwner(devOwnerMember)
                 .customerOwner(customerOwnerMember)
                 .startAt(updateDto.getStartAt())
-                .closeAt(updateDto.getCloseAt())
+                .deadlineAt(updateDto.getDeadlineAt())
                 .updateAt(LocalDateTime.now())
                 .organizations(organizations)
                 .members(members)

--- a/module-service/src/main/java/com/checkping/dto/project/ProjectRequest.java
+++ b/module-service/src/main/java/com/checkping/dto/project/ProjectRequest.java
@@ -145,9 +145,9 @@ public class ProjectRequest {
                 .managementStep(Project.ManagementStep.valueOf(updateDto.getManagementStep()))
                 .devOwner(devOwnerMember)
                 .customerOwner(customerOwnerMember)
+                .updateAt(LocalDateTime.now())
                 .startAt(updateDto.getStartAt())
                 .deadlineAt(updateDto.getDeadlineAt())
-                .updateAt(LocalDateTime.now())
                 .organizations(organizations)
                 .members(members)
                 .build();

--- a/module-service/src/main/java/com/checkping/dto/project/ProjectResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/project/ProjectResponse.java
@@ -44,7 +44,10 @@ public class ProjectResponse {
         @Schema(description = "프로젝트 시작 일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private String startAt;
-        @Schema(description = "프로젝트 마감 일시")
+        @Schema(description = "프로젝트 예상 종료 일시")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private String deadlineAt;
+        @Schema(description = "프로젝트 종료 일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private String closeAt;
         @Schema(description = "프로젝트 삭제여부")
@@ -68,6 +71,7 @@ public class ProjectResponse {
                     .regAt(DateTimeUtils.format(project.getRegAt()))
                     .updateAt(DateTimeUtils.format(project.getUpdateAt()))
                     .startAt(DateTimeUtils.format(project.getStartAt()))
+                    .deadlineAt(DateTimeUtils.format(project.getDeadlineAt()))
                     .closeAt(DateTimeUtils.format(project.getCloseAt()))
                     .deletedYn(project.getDeletedYn())
                     .devOwnerId(project.getDevOwner().getId())
@@ -119,7 +123,10 @@ public class ProjectResponse {
         @Schema(description = "프로젝트 시작 일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime startAt;
-        @Schema(description = "프로젝트 마감 일시")
+        @Schema(description = "프로젝트 예상 종료 일시")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime deadlineAt;
+        @Schema(description = "프로젝트 종료 일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime closeAt;
 
@@ -129,19 +136,20 @@ public class ProjectResponse {
                     .projectName(projectInfo.getProjectName())
                     .description(projectInfo.getDescription())
                     .managementStep(projectInfo.getManagementStep())
-                    .developerOrgName(developerOwnerInfo.getOwnerOrgName())
-                    .developerOwnerName(developerOwnerInfo.getOwnerName())
-                    .developerProfileImageUrl(developerOwnerInfo.getProfileImageUrl())
-                    .developerJobRole(developerOwnerInfo.getJobRole())
-                    .developerJobTitle(developerOwnerInfo.getJobTitle())
-                    .developerPhoneNum(developerOwnerInfo.getPhoneNum())
-                    .customerOrgName(customerOwnerInfo.getOwnerOrgName())
-                    .customerOwnerName(customerOwnerInfo.getOwnerName())
-                    .customerProfileImageUrl(customerOwnerInfo.getProfileImageUrl())
-                    .customerJobRole(customerOwnerInfo.getJobRole())
-                    .customerJobTitle(customerOwnerInfo.getJobTitle())
-                    .customerPhoneNum(customerOwnerInfo.getPhoneNum())
+                    .developerOrgName(developerOwnerInfo != null ? developerOwnerInfo.getOwnerOrgName() : null)
+                    .developerOwnerName(developerOwnerInfo != null ? developerOwnerInfo.getOwnerName() : null)
+                    .developerProfileImageUrl(developerOwnerInfo != null ? developerOwnerInfo.getProfileImageUrl() : null)
+                    .developerJobRole(developerOwnerInfo != null ? developerOwnerInfo.getJobRole() : null)
+                    .developerJobTitle(developerOwnerInfo != null ? developerOwnerInfo.getJobTitle() : null)
+                    .developerPhoneNum(developerOwnerInfo != null ? developerOwnerInfo.getPhoneNum() : null)
+                    .customerOrgName(customerOwnerInfo != null ? customerOwnerInfo.getOwnerOrgName() : null)
+                    .customerOwnerName(customerOwnerInfo != null ? customerOwnerInfo.getOwnerName() : null)
+                    .customerProfileImageUrl(customerOwnerInfo != null ? customerOwnerInfo.getProfileImageUrl() : null)
+                    .customerJobRole(customerOwnerInfo != null ? customerOwnerInfo.getJobRole() : null)
+                    .customerJobTitle(customerOwnerInfo != null ? customerOwnerInfo.getJobTitle() : null)
+                    .customerPhoneNum(customerOwnerInfo != null ? customerOwnerInfo.getPhoneNum() : null)
                     .startAt(projectInfo.getStartAt())
+                    .deadlineAt(projectInfo.getDeadlineAt())
                     .closeAt(projectInfo.getCloseAt())
                     .build();
         }
@@ -172,7 +180,10 @@ public class ProjectResponse {
         @Schema(description = "프로젝트 시작 일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private Date startAt;
-        @Schema(description = "프로젝트 마감 일시")
+        @Schema(description = "프로젝트 예상 종료 일시")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private Date deadlineAt;
+        @Schema(description = "프로젝트 종료 일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private Date closeAt;
         @Schema(description = "프로젝트 삭제여부")
@@ -186,7 +197,7 @@ public class ProjectResponse {
         @Schema(description = "프로젝트 클릭 가능 여부")
         private Integer clickable;
 
-        public ProjectListDetailDto(long id, String name, String description, String detail, String managementStep, Date regAt, Date updateAt, Date startAt, Date closeAt, String deletedYn, long devOwnerId, String developerName, String customerName, int clickable) {
+        public ProjectListDetailDto(long id, String name, String description, String detail, String managementStep, Date regAt, Date updateAt, Date startAt, Date deadlineAt, Date closeAt, String deletedYn, long devOwnerId, String developerName, String customerName, int clickable) {
             this.id = id;
             this.name = name;
             this.description = description;
@@ -195,6 +206,7 @@ public class ProjectResponse {
             this.regAt = regAt;
             this.updateAt = updateAt;
             this.startAt = startAt;
+            this.deadlineAt = deadlineAt;
             this.closeAt = closeAt;
             this.deletedYn = deletedYn;
             this.devOwnerId = devOwnerId;
@@ -254,7 +266,10 @@ public class ProjectResponse {
         @Schema(description = "프로젝트 시작 일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private Date startAt;
-        @Schema(description = "프로젝트 마감 일시")
+        @Schema(description = "프로젝트 예상 종료 일시")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private Date deadlineAt;
+        @Schema(description = "프로젝트 종료 일시")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private Date closeAt;
         @Schema(description = "개발사 대표자 아이디")
@@ -276,6 +291,7 @@ public class ProjectResponse {
                     .detail(detailsDto.getDetail())
                     .managementStep(Project.ManagementStep.valueOf(detailsDto.getManagementStep()))
                     .startAt(detailsDto.getStartAt())
+                    .deadlineAt(detailsDto.getDeadlineAt())
                     .closeAt(detailsDto.getCloseAt())
                     .devOwnerId(detailsDto.getDevOwnerId())
                     .customerOwnerId(detailsDto.getCustomerOrgId())

--- a/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
@@ -278,6 +278,16 @@ public class ProjectServiceImpl implements ProjectService {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND));
 
+        Member member = currentMemberUtil.getCurrentMember();
+
+        // 관리자 및 개발사 대표자만 수정 가능
+        if (member.getRole() != Member.Role.ADMIN) {
+            if (!member.getOrganization().getType().equals(Organization.Type.DEVELOPER) ||
+                    !member.getId().equals(project.getDevOwner().getId())) {
+                throw new BaseException(ErrorCode.BAD_REQUEST);
+            }
+        }
+
         if(Project.ManagementStep.valueOf(managementStep).equals(Project.ManagementStep.COMPLETED)){
             project.updateCloseAt();
         }

--- a/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
@@ -68,6 +68,10 @@ public class ProjectServiceImpl implements ProjectService {
 
         progressStepRepository.saveAll(steps);
 
+        if(project.getManagementStep().equals(Project.ManagementStep.COMPLETED)){
+            project.updateCloseAt();
+        }
+
         Long firstStepId = steps.get(0).getId();
 
         project.updateProgressStep(firstStepId);
@@ -99,6 +103,10 @@ public class ProjectServiceImpl implements ProjectService {
         List<Organization> organizations = getOrganizations(request.getDeveloperOrgId(),
                 request.getCustomerOrgId());
         List<Member> members = getMembers(request.getMembers());
+
+        if(project.getManagementStep().equals(Project.ManagementStep.COMPLETED)){
+            project.updateCloseAt();
+        }
 
         project = projectRepository.save(
                 ProjectRequest.UpdateDto.toEntity(request, project, organizations, members));
@@ -264,6 +272,20 @@ public class ProjectServiceImpl implements ProjectService {
         });
 
         return ProjectResponse.ProjectListByManagementStepDto.toDto(results);
+    }
+
+    public ProjectResponse.ProjectDto updateManagementStep(Long projectId, String managementStep) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND));
+
+        if(Project.ManagementStep.valueOf(managementStep).equals(Project.ManagementStep.COMPLETED)){
+            project.updateCloseAt();
+        }
+
+        project.updateManagementStep(Project.ManagementStep.valueOf(managementStep));
+        projectRepository.save(project);
+
+        return ProjectResponse.ProjectDto.toDto(project);
     }
 
 }

--- a/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/project/ProjectServiceImpl.java
@@ -145,10 +145,9 @@ public class ProjectServiceImpl implements ProjectService {
     public ProjectResponse.ProjectInfoDto findProjectByProjectId(Long projectId) {
         ProjectInfo projectInfo = projectRepository.findProjectInfoById(projectId)
                 .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND));
-        OwnerInfo developerOwnerInfo = projectRepository.findOwnerMemberInfoById(projectInfo.getDeveloperOwnerId())
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND));
-        OwnerInfo customerOwnerInfo = projectRepository.findOwnerMemberInfoById(projectInfo.getCustomerOwnerId())
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND));
+        OwnerInfo developerOwnerInfo = projectRepository.findOwnerMemberInfoById(projectInfo.getDeveloperOwnerId()).orElse(null);
+        OwnerInfo customerOwnerInfo = projectRepository.findOwnerMemberInfoById(projectInfo.getCustomerOwnerId()).orElse(null);
+        // 추후 업체, 멤버가 완전 삭제될 시에도 프로젝트 정보를 가져올 수 있어야 하기 때문에 업체, 멤버에 한해 exception 처리를 제거
 
         return ProjectResponse.ProjectInfoDto.toDto(projectInfo, developerOwnerInfo, customerOwnerInfo);
     }
@@ -210,12 +209,13 @@ public class ProjectServiceImpl implements ProjectService {
                 (Date) row[5], // regAt
                 (Date) row[6], // updateAt
                 (Date) row[7], // startAt
-                (Date) row[8], // closeAt
-                (String) row[9], // deletedYn
-                ((Number) row[10]).longValue(), // devOwnerId
-                (String) row[11], // developerName
-                (String) row[12], // customerName
-                ((Number) row[13]).intValue() // clickable
+                (Date) row[8], // deadlineAt
+                (Date) row[9], // closeAt
+                (String) row[10], // deletedYn
+                ((Number) row[11]).longValue(), // devOwnerId
+                (String) row[12], // developerName
+                (String) row[13], // customerName
+                ((Number) row[14]).intValue() // clickable
         ));
     }
 

--- a/module-service/src/test/java/com/checkping/service/ProjectServiceTests.java
+++ b/module-service/src/test/java/com/checkping/service/ProjectServiceTests.java
@@ -2,8 +2,8 @@ package com.checkping.service;
 
 import com.checkping.domain.member.Organization;
 import com.checkping.domain.project.Project;
-import com.checkping.dto.ProjectRequest;
-import com.checkping.dto.ProjectResponse;
+import com.checkping.dto.project.ProjectRequest;
+import com.checkping.dto.project.ProjectResponse;
 import com.checkping.infra.repository.member.OrganizationRepository;
 import com.checkping.infra.repository.project.ProjectRepository;
 import com.checkping.service.project.ProjectServiceImpl;
@@ -39,9 +39,6 @@ public class ProjectServiceTests {
                         .name("이름")
                         .description("설명")
                         .detail("상세설명")
-                        .status(String.valueOf(Project.Status.IN_PROGRESS))
-                        .closeAt(LocalDate.parse("2025-12-30").atStartOfDay())
-                        .resisterId(49283L)
                         .build());
 
         List<Project> projects = projectRepository.findAll();
@@ -56,9 +53,6 @@ public class ProjectServiceTests {
                         .name("이름")
                         .description("설명")
                         .detail("상세설명")
-                        .status(String.valueOf(Project.Status.IN_PROGRESS))
-                        .closeAt(LocalDate.parse("2025-12-30").atStartOfDay())
-                        .resisterId(49283L)
                         .build());
 
         Project project = projectRepository.findById(1L).get();
@@ -80,9 +74,6 @@ public class ProjectServiceTests {
                             .name("이름" + i)
                             .description("설명")
                             .detail("상세설명")
-                            .status(String.valueOf(Project.Status.IN_PROGRESS))
-                            .closeAt(defaultCloseAt)
-                            .resisterId(resisterId)
                             .build());
 
             System.out.println("resisterProject : " + resisterDto);
@@ -93,9 +84,6 @@ public class ProjectServiceTests {
                         .name("프로젝트이름")
                         .description("설명123")
                         .detail("상세설명")
-                        .status(String.valueOf(Project.Status.PAUSED))
-                        .closeAt(LocalDate.parse("2025-06-30").atStartOfDay())
-                        .updaterId(resisterId)
                         .build());
 
         List<Project> list = projectRepository.findAll();
@@ -133,7 +121,6 @@ public class ProjectServiceTests {
                 .name("이름")
                 .description("설명")
                 .detail("상세설명")
-                .status(Project.Status.IN_PROGRESS)
                 .regAt(LocalDateTime.now())
                 .closeAt(LocalDate.parse("2025-12-30").atStartOfDay())
                 .resisterId(49283L)
@@ -148,8 +135,8 @@ public class ProjectServiceTests {
         List<Project> projects = projectRepository.findAll();
         System.out.println("p : " + projects.get(0));
 
-        List<ProjectResponse.ProjectDto> list = projectService.findAllProjects("이름","IN_PROGRESS");
-        System.out.println(list);
+        //List<ProjectResponse.ProjectDto> list = projectService.findAllProjects("이름","IN_PROGRESS");
+        //System.out.println(list);
 
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

프로젝트 관리단계 수정 api 생성

## #️⃣ 연관된 이슈

#410

## 📋 작업 내용

project 엔티티 내용 추가
- deadline_at(프로젝트 예상 종료 일시) 추가
- management_step을 업데이트하는 메서드 추가
- close_at을 업데이트하는 메서드 추가

엔드포인트 추가
- 프로젝트 관리단계 수정 api 엔드포인트 추가

서비스 로직, request dto 수정/추가
- 관리자 및 개발사 대표자만 관리단계 수정 가능
- 프로젝트 생성/수정 시 받는 정보가 close_at -> deadline_at으로 변경
- 프로젝트 생성/수정 시 관리단계가 납품완료(COMPLETED)일 경우 close_at(프로젝트 실제 종료일시) 현재 시각으로 업데이트

deadline_at 추가에 따른 변경 및 특정 exception 처리 제거
- close_at -> deadline_at으로 변경
- response에 deadline_at, close_at 모두 존재하도록 변경
- 추후 업체, 멤버가 완전 삭제될 시에도 프로젝트 정보를 가져올 수 있어야 하기 때문에 업체, 멤버에 한해 exception 처리를 제거