### PR TITLE
Feature/392 feature 결재 유형 추가

### DIFF
--- a/module-domain/src/main/java/com/checkping/domain/approval/Approval.java
+++ b/module-domain/src/main/java/com/checkping/domain/approval/Approval.java
@@ -139,7 +139,8 @@ public class Approval extends BaseEntity {
     Generate
      */
 
-    public static Approval generate(Project project, ProgressStep progressStep, Member register,
+    public static Approval generate(Project project, ProgressStep progressStep,
+        ApprovalCategory category, Member register,
         String title, String content) {
 
         Approval approval = new Approval();
@@ -149,6 +150,8 @@ public class Approval extends BaseEntity {
         approval.project = project;
         approval.progressStep = progressStep;
         approval.register = register;
+
+        approval.category = category;
 
         // 생성 시 기본 값
         approval.status = ApprovalStatus.WAIT;

--- a/module-domain/src/main/java/com/checkping/domain/approval/Approval.java
+++ b/module-domain/src/main/java/com/checkping/domain/approval/Approval.java
@@ -37,7 +37,6 @@ public class Approval extends BaseEntity {
     status : 결재 상태
     register : 작성자 (FK : register_id)
     register_name : 작성자 이름
-    cancle_at : 취소 일자
     approver_at : 승인 일시
     approver_id : 승인자 id
     approver_name : 승인자 이름
@@ -70,9 +69,6 @@ public class Approval extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "register_id")
     private Member register;
-
-    @Column(name = "cancel_at")
-    private LocalDateTime cancelAt;
 
     @Column(name = "approver_at")
     private LocalDateTime approverAt;
@@ -187,7 +183,6 @@ public class Approval extends BaseEntity {
         this.status = ApprovalStatus.REJECTED;
         this.approver = rejector;
         this.approverName = rejector.getName();
-        this.cancelAt = LocalDateTime.now();
         this.approverAt = LocalDateTime.now();
     }
 

--- a/module-domain/src/main/java/com/checkping/domain/approval/Approval.java
+++ b/module-domain/src/main/java/com/checkping/domain/approval/Approval.java
@@ -35,6 +35,7 @@ public class Approval extends BaseEntity {
     title : 제목
     content : 내용
     status : 결재 상태
+    category : 결재 카테고리
     register : 작성자 (FK : register_id)
     register_name : 작성자 이름
     approver_at : 승인 일시
@@ -57,7 +58,6 @@ public class Approval extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "progress_step_id")
     private ProgressStep progressStep;
-
 
     @Column(name = "title", nullable = false, length = 100)
     private String title;
@@ -106,6 +106,10 @@ public class Approval extends BaseEntity {
     private ApprovalStatus status;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private ApprovalCategory category;
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "deleted_yn", nullable = false)
     private DeleteStatus deleteYn;
 
@@ -120,6 +124,14 @@ public class Approval extends BaseEntity {
     @RequiredArgsConstructor
     public enum DeleteStatus {
         Y("비활성화"), N("활성화");
+        private final String description;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum ApprovalCategory {
+        NORMAL_REQUEST("일반 요청"), COMPLETE_REQUEST("완료 요청");
+
         private final String description;
     }
 

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalConfirm.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalConfirm.java
@@ -39,7 +39,6 @@ public class ApprovalConfirm {
         projectId : 프로젝트 ID
         approvalId : 결재 ID
         status : 변경된 결재 상태
-        cancelAt : 취소 일시
         approverAt : 승인 일시
         approver : 승인자
          */
@@ -49,8 +48,6 @@ public class ApprovalConfirm {
         private Long approvalId;
         @Schema(description = "변경된 결재 상태", example = "REJECTED, APPROVED")
         private String status;
-        @Schema(description = "취소 일시", example = "2021-07-01T00:00:00")
-        private String cancelAt;
         @Schema(description = "승인 일시", example = "2021-07-01T00:00:00")
         private String approverAt;
         @Schema(description = "승인자")
@@ -68,12 +65,10 @@ public class ApprovalConfirm {
             response.approvalId = approval.getId();
             response.status = approval.getStatus().name();
 
-            response.cancelAt = null;
             response.approverAt = null;
             response.approver = null;
 
             if (!approval.isWaitStatus()) {
-                response.cancelAt = DateTimeUtils.format(approval.getCancelAt());
                 response.approverAt = DateTimeUtils.format(approval.getApproverAt());
                 response.approver = MemberResponseDto.MeWithSignatureResponseDto.fromEntity(approval.getApprover());
             }

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalConfirm.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalConfirm.java
@@ -39,6 +39,7 @@ public class ApprovalConfirm {
         projectId : 프로젝트 ID
         approvalId : 결재 ID
         status : 변경된 결재 상태
+        category : 결재 카테고리
         approverAt : 승인 일시
         approver : 승인자
          */
@@ -48,6 +49,8 @@ public class ApprovalConfirm {
         private Long approvalId;
         @Schema(description = "변경된 결재 상태", example = "REJECTED, APPROVED")
         private String status;
+        @Schema(description = "결재 카테고리", example = "NORMAL_REQUEST, COMPLETE_REQUEST")
+        private String category;
         @Schema(description = "승인 일시", example = "2021-07-01T00:00:00")
         private String approverAt;
         @Schema(description = "승인자")
@@ -64,6 +67,7 @@ public class ApprovalConfirm {
             response.projectId = approval.getProject().getId();
             response.approvalId = approval.getId();
             response.status = approval.getStatus().name();
+            response.category = approval.getCategory().name();
 
             response.approverAt = null;
             response.approver = null;

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalGet.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalGet.java
@@ -2,6 +2,7 @@ package com.checkping.dto.approval;
 
 import com.checkping.common.utils.DateTimeUtils;
 import com.checkping.domain.approval.Approval;
+import com.checkping.domain.approval.Approval.ApprovalCategory;
 import com.checkping.domain.approval.Approval.ApprovalStatus;
 import com.checkping.dto.approval.comment.ApprovalCommentGet;
 import com.checkping.dto.approval.file.ApprovalFileGet;
@@ -27,9 +28,9 @@ public class ApprovalGet {
         title : 결재 제목
         content : 결재 내용
         status : 결재 상태
+        category : 결재 카테고리
         registerId : 작성자 id
         registerName : 작성자 이름
-        cancleAt : 취소 일자
         approverAt : 승인 일시
         approver : 승인자
         updatedAt : 수정 일시
@@ -50,6 +51,8 @@ public class ApprovalGet {
         private List<ApprovalContent> content;
         @Schema(description = "결재 상태")
         private ApprovalStatus status;
+        @Schema(description = "결재 카테고리", example = "NORMAL_REQUEST, COMPLETE_REQUEST")
+        private ApprovalCategory category;
         @Schema(description = "작성자 (서명 포함)")
         private MemberResponseDto.MeWithSignatureResponseDto register;
         @Schema(description = "승인 일시")
@@ -81,6 +84,7 @@ public class ApprovalGet {
             response.title = approval.getTitle();
             response.content = ApprovalContent.toContentList(approval.getContent());
             response.status = approval.getStatus();
+            response.category = approval.getCategory();
             response.register = MemberResponseDto.MeWithSignatureResponseDto.fromEntity(
                 approval.getRegister());
             response.updatedAt = DateTimeUtils.format(approval.getUpdatedAt());

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalGet.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalGet.java
@@ -52,8 +52,6 @@ public class ApprovalGet {
         private ApprovalStatus status;
         @Schema(description = "작성자 (서명 포함)")
         private MemberResponseDto.MeWithSignatureResponseDto register;
-        @Schema(description = "취소 일자")
-        private String cancelAt;
         @Schema(description = "승인 일시")
         private String approverAt;
         @Schema(description = "승인자 (서명 포함)")
@@ -93,10 +91,9 @@ public class ApprovalGet {
 
             response.approverAt = null;
             response.approver = null;
-            response.cancelAt = null;
+
             // 대기상태가 아니면 승인 일시, 승인자 정보를 추가
             if (!approval.isWaitStatus()) {
-                response.cancelAt = DateTimeUtils.format(approval.getCancelAt());
                 response.approverAt = DateTimeUtils.format(approval.getApproverAt());
                 response.approver = MemberResponseDto.MeWithSignatureResponseDto.fromEntity(
                     approval.getApprover());

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalRegister.java
@@ -73,7 +73,6 @@ public class ApprovalRegister {
         category : 결재 유형
         registerId : 작성자 id
         registerName : 작성자 이름
-        cancleAt : 취소 일자
         approverAt : 승인 일시
         approver : 승인자
         updatedAt : 수정 일시
@@ -89,7 +88,6 @@ public class ApprovalRegister {
         private String status;
         private String category;
         private MeResponseDto register;
-        private LocalDateTime cancelAt;
         private LocalDateTime approverAt;
         private MeResponseDto approver;
         private LocalDateTime updatedAt;
@@ -107,7 +105,6 @@ public class ApprovalRegister {
             dto.status = approval.getStatus().name();
             dto.category = approval.getCategory().name();
             dto.register = MeResponseDto.fromEntity(approval.getRegister());
-            dto.cancelAt = null;
             dto.approverAt = null;
             dto.approver = null;
             dto.updatedAt = approval.getUpdatedAt();

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalRegister.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalRegister.java
@@ -2,6 +2,7 @@ package com.checkping.dto.approval;
 
 import com.checkping.common.utils.FileRequest;
 import com.checkping.domain.approval.Approval;
+import com.checkping.domain.approval.Approval.ApprovalCategory;
 import com.checkping.domain.member.Member;
 import com.checkping.domain.project.ProgressStep;
 import com.checkping.domain.project.Project;
@@ -9,10 +10,12 @@ import com.checkping.dto.approval.file.ApprovalFileRegister;
 import com.checkping.dto.approval.link.ApprovalLinkRegister;
 import com.checkping.dto.member.response.MemberResponseDto.MeResponseDto;
 import com.checkping.dto.project.ProgressStepGet;
+import com.checkping.exception.approval.ApprovalCategoryException;
 import com.checkping.exception.approval.ApprovalContentParsingException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.constraints.NotEmpty;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AccessLevel;
@@ -29,10 +32,13 @@ public class ApprovalRegister {
         progress_step_id : 프로젝트 진행 단계 id
         title : 제목
         content : 내용
+        category : 결재 유형
         fileInfoList : 첨부 파일
          */
         private Long progressStepId;
         private String title;
+        @NotEmpty(message = "결재 유형을 입력해주세요")
+        private String category;
         private List<ApprovalContent> content;
         private List<FileRequest> fileInfoList;
         private List<ApprovalLinkRegister.Request> linkList;
@@ -40,8 +46,8 @@ public class ApprovalRegister {
 
         public static Approval toEntity(Project project, ProgressStep progressStep, Member register,
             Request request) {
-            return Approval.generate(project, progressStep, register, request.title,
-                request.jsonToString());
+            return Approval.generate(project, progressStep, convertCategory(request.category),
+                register, request.title, request.jsonToString());
         }
 
         private String jsonToString() {
@@ -64,6 +70,7 @@ public class ApprovalRegister {
         title : 제목
         content : 내용
         status : 결재 상태
+        category : 결재 유형
         registerId : 작성자 id
         registerName : 작성자 이름
         cancleAt : 취소 일자
@@ -80,6 +87,7 @@ public class ApprovalRegister {
         private String title;
         private List<ApprovalContent> content;
         private String status;
+        private String category;
         private MeResponseDto register;
         private LocalDateTime cancelAt;
         private LocalDateTime approverAt;
@@ -97,6 +105,7 @@ public class ApprovalRegister {
             dto.title = approval.getTitle();
             dto.content = ApprovalRegister.Response.stringToJson(approval.getContent());
             dto.status = approval.getStatus().name();
+            dto.category = approval.getCategory().name();
             dto.register = MeResponseDto.fromEntity(approval.getRegister());
             dto.cancelAt = null;
             dto.approverAt = null;
@@ -116,6 +125,21 @@ public class ApprovalRegister {
             } catch (JsonProcessingException e) {
                 throw new ApprovalContentParsingException();
             }
+        }
+    }
+
+    /**
+     * Enum : ApprovalCategory 변환 함수
+     *
+     * @param value ApprovalCategory 로 변환할 문자열
+     * @return ApprovalCategory
+     * @throws ApprovalCategoryException ApprovalCategory 변환 실패
+     */
+    public static Approval.ApprovalCategory convertCategory(String value) {
+        try {
+            return Approval.ApprovalCategory.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new ApprovalCategoryException();
         }
     }
 

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalSearch.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalSearch.java
@@ -28,7 +28,6 @@ public class ApprovalSearch {
         updatedAt : 수정일
         approvedAt : 결재일
         approval : 결재자
-        cancelAt : 취소일
         isDeleted : 삭제 여부
          */
         private Long id;
@@ -41,7 +40,6 @@ public class ApprovalSearch {
         private String updatedAt;
         private String approvedAt;
         private MeResponseDto approver;
-        private String cancelAt;
         private boolean isDeleted;
 
 
@@ -63,7 +61,6 @@ public class ApprovalSearch {
             dto.updatedAt = DateTimeUtils.format(approval.getUpdatedAt());
             dto.approvedAt = DateTimeUtils.format(approval.getApproverAt());
             dto.approver = approval.getApprover() == null ? null : MeResponseDto.fromEntity(approval.getApprover());
-            dto.cancelAt = DateTimeUtils.format(approval.getCancelAt());
             dto.isDeleted = approval.getDeleteYn() == Approval.DeleteStatus.Y;
             return dto;
         }

--- a/module-service/src/main/java/com/checkping/dto/approval/ApprovalSearch.java
+++ b/module-service/src/main/java/com/checkping/dto/approval/ApprovalSearch.java
@@ -23,6 +23,7 @@ public class ApprovalSearch {
         progressStepId : 프로젝트 진행 단계 ID
         title : 결재 제목
         status : 결재 상태
+        category : 결재 카테고리
         register : 작성자
         regAt : 작성일
         updatedAt : 수정일
@@ -35,6 +36,7 @@ public class ApprovalSearch {
         private ProgressStepGet.Response progressStep;
         private String title;
         private String status;
+        private String category;
         private MeResponseDto register;
         private String regAt;
         private String updatedAt;
@@ -56,6 +58,7 @@ public class ApprovalSearch {
             dto.progressStep = ProgressStepGet.Response.toDto(approval.getProgressStep());
             dto.title = approval.getTitle();
             dto.status = approval.getStatus().name();
+            dto.category = approval.getCategory().name();
             dto.register = MeResponseDto.fromEntity(approval.getRegister());
             dto.regAt = DateTimeUtils.format(approval.getRegAt());
             dto.updatedAt = DateTimeUtils.format(approval.getUpdatedAt());

--- a/module-service/src/main/java/com/checkping/exception/approval/ApprovalCategoryException.java
+++ b/module-service/src/main/java/com/checkping/exception/approval/ApprovalCategoryException.java
@@ -1,0 +1,10 @@
+package com.checkping.exception.approval;
+
+import com.checkping.common.enums.ErrorCode;
+
+public class ApprovalCategoryException extends ApprovalException {
+
+    public ApprovalCategoryException() {
+        super("허용되는 결재 유형이 아닙니다.", ErrorCode.BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request

**[결재 유형 추가]**

## #️⃣ 연관된 이슈

- #392 

## 📋 작업 내용

1. 결재 취소일자(`cancelAt`) 삭제
-> 결재 승인일자와 결재 승인자, 결재 상태를 통해서 판별하는 것으로 변경하였습니다.
2. 결재 유형 생성
- NORMAL_REQUEST("일반 요청")
- COMPLETE_REQUEST("완료 요청")
-> 프로젝트 진행 단계를 완료 요청을 목적의 결재는 COMPLETE_REQUEST 로 보냅니다. 