### PR TITLE
fix : 결재 상세 조회 시 댓글이 없으면 조회가 안되는 이슈 해결

### DIFF
--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepositoryImpl.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalCustomRepositoryImpl.java
@@ -82,7 +82,7 @@ public class ApprovalCustomRepositoryImpl implements ApprovalCustomRepository {
 
         // ✅ 총 개수 조회
         long total = ofNullable(
-                queryFactory.select(approval.count()).from(approval).where(builder).fetchOne())
+            queryFactory.select(approval.count()).from(approval).where(builder).fetchOne())
             .orElse(0L);
 
         // ✅ 페이징된 데이터 조회
@@ -110,16 +110,19 @@ public class ApprovalCustomRepositoryImpl implements ApprovalCustomRepository {
         // ✅ 삭제상태 조건: 삭제된 데이터도 조회
         if (!isDeleted) {
             builder.and(approval.deleteYn.eq(Approval.DeleteStatus.N));
+            // 댓글이 없거나 삭제되지 않은 상태만 조회
+            builder.and(
+                approvalComment.isNull()
+                    .or(approvalComment.deleteYn.eq(
+                        ApprovalComment.DeleteStatus.N))); // ✅ 삭제된 데이터는 조회하지 않음
         }
 
         // ✅ 결재 데이터 조회
         Approval result = queryFactory
             .selectFrom(approval)
-            .leftJoin(approval.commentList, approvalComment).fetchJoin() // ✅ 댓글 리스트 조회
-            .where(
-                builder,
-                isDeleted ? null : approvalComment.deleteYn.eq(ApprovalComment.DeleteStatus.N) // ✅ 삭제된 데이터는 조회하지 않음
-            ).fetchOne();
+            .leftJoin(approval.commentList, approvalComment)
+            .where(builder)
+            .fetchOne();
 
         return Optional.ofNullable(result); // ✅ 결과를 Optional로 감싸서 반환
     }


### PR DESCRIPTION
# 🚀 Pull Request

**[결재 상세 조회 시 댓글이 없으면 조회가 안되는 이슈 해결]**

## #️⃣ 연관된 이슈

- #440

## 📋 작업 내용

- 댓글이 없어도 조회되도록 쿼리 조건을 수정
