### PR TITLE
Feature/435 회원 비활성화 기능 수정

### DIFF
--- a/module-api/src/main/java/com/checkping/api/auth/config/CustomSecurityConfig.java
+++ b/module-api/src/main/java/com/checkping/api/auth/config/CustomSecurityConfig.java
@@ -2,13 +2,14 @@ package com.checkping.api.auth.config;
 
 import com.checkping.api.auth.filter.JWTFilter;
 import com.checkping.api.exceptionhandler.CustomAccessDeniedHandler;
-import com.checkping.service.member.MemberService;
+import com.checkping.service.member.auth.RedisConnectionCheckService;
 import com.checkping.service.member.auth.TokenBlacklistService;
 import com.checkping.service.member.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.server.CookieSameSiteSupplier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -35,8 +36,9 @@ public class CustomSecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtUtil jwtUtil;
     private final TokenBlacklistService tokenBlacklistService;
-    private final MemberService memberService;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final StringRedisTemplate redisTemplateForInactiveMembers;
+    private final RedisConnectionCheckService redisConnectionCheckService;
 
     //AuthenticationManager Bean 등록
     @Bean
@@ -76,7 +78,7 @@ public class CustomSecurityConfig {
 
         http.exceptionHandling((exception) -> exception.accessDeniedHandler(customAccessDeniedHandler));
 
-        http.addFilterBefore(new JWTFilter(jwtUtil,tokenBlacklistService,memberService), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new JWTFilter(jwtUtil,tokenBlacklistService, redisTemplateForInactiveMembers, redisConnectionCheckService), UsernamePasswordAuthenticationFilter.class);
 
         //세션 설정
         http.sessionManagement(

--- a/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
@@ -1,18 +1,21 @@
 package com.checkping.api.auth.filter;
 
+import com.checkping.api.auth.util.CookieUtil;
 import com.checkping.api.auth.util.ResponseUtil;
 import com.checkping.common.enums.ErrorCode;
 import com.checkping.common.response.BaseResponse;
-import com.checkping.service.member.MemberService;
 import com.checkping.service.member.auth.CustomUserDetails;
+import com.checkping.service.member.auth.RedisConnectionCheckService;
 import com.checkping.service.member.auth.TokenBlacklistService;
 import com.checkping.service.member.util.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -28,7 +31,8 @@ public class JWTFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
     private final TokenBlacklistService tokenBlacklistService;
-    private final MemberService memberService;
+    private final StringRedisTemplate redisTemplateForInactiveMembers;
+    private final RedisConnectionCheckService redisConnectionCheckService;
 
     // TODO 필터 거치지 않을 경로 설정
     @Override
@@ -59,16 +63,41 @@ public class JWTFilter extends OncePerRequestFilter {
             return;
         }
 
+        // 엑세스 토큰에서 사용자 ID 추출
+        Long id = jwtUtil.getMemberId(accessToken);
+
         try {
             // 토큰 만료 여부 확인
             jwtUtil.isExpired(accessToken);
 
-            // 3) Redis 블랙리스트 검증 (연결 여부 먼저 확인)
-            if (tokenBlacklistService.isRedisAvailable()) {
-                // 실제 Redis 연결이 된다면 블랙리스트 검사
+            // 3) Redis 블랙리스트, 회원 활성화 여부 검증 (연결 여부 먼저 확인)
+            if (redisConnectionCheckService.isRedisAvailable()) {
+
+                // 1. 요청한 토큰 블랙리스트에 있는지 확인
                 if (tokenBlacklistService.isAccessTokenBlacklisted(accessToken)) {
                     BaseResponse errorResponse = BaseResponse.fail(ErrorCode.BLACKLISTED_TOKEN);
                     ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
+                    return;
+                }
+
+                // 2. 비활성화 회원인지 확인
+                Boolean isInactive = redisTemplateForInactiveMembers.hasKey("inactive:member:" + id);
+
+                if (Boolean.TRUE.equals(isInactive)) {
+                    // 비활성화된 회원이 보낸 토큰을 블랙리스트에 추가
+                    tokenBlacklistService.blacklistAccessToken(accessToken, jwtUtil.getExpiration(accessToken));
+                    // 리프레시 토큰도 블랙리스트에 추가
+                    String refreshToken = jwtUtil.extractToken(request, "refresh");
+                    tokenBlacklistService.blacklistRefreshToken(refreshToken, jwtUtil.getExpiration(refreshToken));
+
+                    // 쿠키 삭제
+                    Cookie delAccess = CookieUtil.deleteCookie("access");
+                    Cookie delRefresh = CookieUtil.deleteCookie("refresh");
+                    response.addCookie(delAccess);
+                    response.addCookie(delRefresh);
+
+                    BaseResponse errorResponse = BaseResponse.fail(ErrorCode.INACTIVE_MEMBER);
+                    ResponseUtil.sendErrorResponse(response, HttpStatus.FORBIDDEN, errorResponse);
                     return;
                 }
             }
@@ -77,14 +106,6 @@ public class JWTFilter extends OncePerRequestFilter {
             String name = jwtUtil.getName(accessToken);
             String email = jwtUtil.getEmail(accessToken);
             String role = jwtUtil.getRole(accessToken);
-            Long id = jwtUtil.getMemberId(accessToken);
-
-            String memberStatus = memberService.getMemberStatus(id);
-            if (!memberStatus.equals("ACTIVE")) {
-                BaseResponse errorResponse = BaseResponse.fail(ErrorCode.INACTIVE_OR_DELETED_MEMBER);
-                ResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
-                return;
-            }
 
             CustomUserDetails customUserDetails = new CustomUserDetails(id, name, email, role, "PASSWORDFORTOKEN");
             Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, List.of(new SimpleGrantedAuthority(customUserDetails.getRole())));

--- a/module-common/src/main/java/com/checkping/common/config/RedisConfig.java
+++ b/module-common/src/main/java/com/checkping/common/config/RedisConfig.java
@@ -27,7 +27,7 @@ public class RedisConfig {
     // 1번 저장소 사용 - 비활성화 회원 목록
     @Bean
     public RedisConnectionFactory redisConnectionFactoryForInactiveMembers() {
-        LettuceConnectionFactory factory = new LettuceConnectionFactory("localhost", 6379);
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(redisHost, redisPort);
         factory.setDatabase(1);
         return factory;
     }

--- a/module-common/src/main/java/com/checkping/common/config/RedisConfig.java
+++ b/module-common/src/main/java/com/checkping/common/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -17,17 +18,31 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int redisPort;
 
+    // 0번 저장소 사용 - 토큰 블랙리스트
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(redisHost,redisPort);
+        return new LettuceConnectionFactory(redisHost, redisPort);
     }
 
+    // 1번 저장소 사용 - 비활성화 회원 목록
     @Bean
+    public RedisConnectionFactory redisConnectionFactoryForInactiveMembers() {
+        LettuceConnectionFactory factory = new LettuceConnectionFactory("localhost", 6379);
+        factory.setDatabase(1);
+        return factory;
+    }
+
+    @Bean // 0번 저장소 사용
     public RedisTemplate<String, String> redisTemplate() {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
+    }
+
+    @Bean // 1번 저장소 사용
+    public StringRedisTemplate redisTemplateForInactiveMembers() {
+        return new StringRedisTemplate(redisConnectionFactoryForInactiveMembers());
     }
 }

--- a/module-service/src/main/java/com/checkping/service/member/MemberService.java
+++ b/module-service/src/main/java/com/checkping/service/member/MemberService.java
@@ -15,10 +15,14 @@ import com.checkping.dto.member.response.MemberSignatureResponseDto;
 import com.checkping.exception.member.InvalidInputValueException;
 import com.checkping.infra.repository.member.MemberRepository;
 import com.checkping.infra.repository.member.OrganizationRepository;
+import com.checkping.service.member.auth.RedisConnectionCheckService;
 import com.checkping.service.member.util.CurrentMemberUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,21 +30,17 @@ import org.springframework.transaction.annotation.Transactional;
 // TODO BaseException 을 상속하는 커스텀 Exception 작성하기
 
 @Service
+@RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;          // 도메인 인터페이스
     private final OrganizationRepository organizationRepository; // 조직 레포지토리(예: JPA)
     private final BCryptPasswordEncoder passwordEncoder;
     private final CurrentMemberUtil currentMemberUtil;
+    private final StringRedisTemplate redisTemplateForInactiveMemers;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisConnectionCheckService redisConnectionCheckService;
 
-    public MemberService(MemberRepository memberRepository,
-        OrganizationRepository organizationRepository, BCryptPasswordEncoder passwordEncoder,
-        CurrentMemberUtil currentMemberUtil) {
-        this.memberRepository = memberRepository;
-        this.organizationRepository = organizationRepository;
-        this.passwordEncoder = passwordEncoder;
-        this.currentMemberUtil = currentMemberUtil;
-    }
 
     // 아이디로 회원 조회
     public MemberResponseDto getMemberById(Long memberId) {
@@ -248,6 +248,11 @@ public class MemberService {
         }
         member.activateAccount();
         memberRepository.save(member);
+
+        // Redis 1번 저장소에 비활성화된 회원 ID 삭제
+        if(redisConnectionCheckService.isRedisAvailable()){
+            redisTemplateForInactiveMemers.delete("inactive:member:" + memberId);
+        }
     }
 
     /*
@@ -269,6 +274,12 @@ public class MemberService {
         }
         member.deactivateAccount();
         memberRepository.save(member);
+
+        // Redis 1번 저장소에 비활성화된 회원 ID 저장
+        if(redisConnectionCheckService.isRedisAvailable()){
+            redisTemplateForInactiveMemers.opsForValue().set("inactive:member:" + memberId, "true");
+        }
+
     }
 
     public String getMemberStatus(Long memberId) {

--- a/module-service/src/main/java/com/checkping/service/member/auth/AuthService.java
+++ b/module-service/src/main/java/com/checkping/service/member/auth/AuthService.java
@@ -22,6 +22,7 @@ public class AuthService {
     private final JwtUtil jwtUtil;
     private final CurrentMemberUtil currentMemberUtil;
     private final TokenBlacklistService tokenBlacklistService;
+    private final RedisConnectionCheckService redisConnectionCheckService;
 
     public BaseResponse getCurrentMember() {
         return BaseResponse.success(MemberResponseDto.MeResponseDto.fromEntity(currentMemberUtil.getCurrentMember()));
@@ -79,7 +80,7 @@ public class AuthService {
         }
 
         // 레디스 연결 여부 먼저 확인
-        if(tokenBlacklistService.isRedisAvailable()) {
+        if(redisConnectionCheckService.isRedisAvailable()) {
             // 블랙리스트 추가
             tokenBlacklistService.blacklistRefreshToken(refresh, jwtUtil.getExpiration(refresh));
             if (accessToken != null) {

--- a/module-service/src/main/java/com/checkping/service/member/auth/RedisConnectionCheckService.java
+++ b/module-service/src/main/java/com/checkping/service/member/auth/RedisConnectionCheckService.java
@@ -1,0 +1,37 @@
+package com.checkping.service.member.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.*;
+
+@Service
+@RequiredArgsConstructor
+public class RedisConnectionCheckService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public boolean isRedisAvailable() {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Boolean> future = executor.submit(() -> {
+            try {
+                String pong = redisTemplate.getConnectionFactory().getConnection().ping();
+                return "PONG".equalsIgnoreCase(pong);
+            } catch (Exception e) {
+                return false;
+            }
+        });
+
+        try {
+            return future.get(500, TimeUnit.MILLISECONDS); // 0.5초 이상 걸리면 false 반환
+        } catch (TimeoutException e) {
+            System.out.println("[RedisConnectionCheck] Redis connection timeout -> Skip blacklist check");
+            return false;
+        } catch (Exception e) {
+            return false;
+        } finally {
+            executor.shutdown();
+        }
+    }
+}

--- a/module-service/src/main/java/com/checkping/service/member/auth/ReissueService.java
+++ b/module-service/src/main/java/com/checkping/service/member/auth/ReissueService.java
@@ -5,20 +5,17 @@ import com.checkping.infra.repository.member.MemberRepository;
 import com.checkping.service.member.util.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class ReissueService {
 
     private final JwtUtil jwtUtil;
     private final MemberRepository memberRepository;
     private final TokenBlacklistService tokenBlacklistService; // 추가
-
-    public ReissueService(JwtUtil jwtUtil, MemberRepository memberRepository, TokenBlacklistService tokenBlacklistService) {
-        this.jwtUtil = jwtUtil;
-        this.memberRepository = memberRepository;
-        this.tokenBlacklistService = tokenBlacklistService; // 추가
-    }
+    private final RedisConnectionCheckService redisConnectionCheckService;
 
     /**
      * 쿠키에서 Refresh Token 추출 및 검증
@@ -42,7 +39,7 @@ public class ReissueService {
      */
     public boolean isRefreshTokenBlacklisted(String refreshToken) {
         // 1) Redis 연결 여부 확인
-        if (!tokenBlacklistService.isRedisAvailable()) {
+        if (!redisConnectionCheckService.isRedisAvailable()) {
             // Redis가 연결 안 되어 있으면 블랙리스트 검증 스킵
             return false;
         }
@@ -57,7 +54,7 @@ public class ReissueService {
     public void checkTokenValidity(String refreshToken) {
         try {
             // 블랙리스트에 있는지 확인
-            if (tokenBlacklistService.isRedisAvailable()) {
+            if (redisConnectionCheckService.isRedisAvailable()) {
                 if (tokenBlacklistService.isRefreshTokenBlacklisted(refreshToken)) { // 수정
                     throw new BlacklistedTokenException();
                 }

--- a/module-service/src/main/java/com/checkping/service/member/auth/TokenBlacklistService.java
+++ b/module-service/src/main/java/com/checkping/service/member/auth/TokenBlacklistService.java
@@ -14,48 +14,23 @@ public class TokenBlacklistService {
         this.redisTemplate = redisTemplate;
     }
 
-    // Redis 연결 가능 여부 체크 메서드
-
-    public boolean isRedisAvailable() {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        Future<Boolean> future = executor.submit(() -> {
-            try {
-                String pong = redisTemplate.getConnectionFactory().getConnection().ping();
-                return "PONG".equalsIgnoreCase(pong);
-            } catch (Exception e) {
-                return false;
-            }
-        });
-
-        try {
-            return future.get(500, TimeUnit.MILLISECONDS); // 0.1초 이상 걸리면 false 반환
-        } catch (TimeoutException e) {
-            System.out.println("[JWTFilter] Redis connection timeout -> Skip blacklist check");
-            return false;
-        } catch (Exception e) {
-            return false;
-        } finally {
-            executor.shutdown();
-        }
-    }
-
     // Access Token 블랙리스트 저장
     public void blacklistAccessToken(String token, long expiration) {
-        redisTemplate.opsForValue().set("access_" + token, "blacklisted", expiration, TimeUnit.MILLISECONDS);
+        redisTemplate.opsForValue().set("access:" + token, "blacklisted", expiration, TimeUnit.MILLISECONDS);
     }
 
     // Refresh Token 블랙리스트 저장
     public void blacklistRefreshToken(String token, long expiration) {
-        redisTemplate.opsForValue().set("refresh_" + token, "blacklisted", expiration, TimeUnit.MILLISECONDS);
+        redisTemplate.opsForValue().set("refresh:" + token, "blacklisted", expiration, TimeUnit.MILLISECONDS);
     }
 
     // Access Token 블랙리스트 확인
     public boolean isAccessTokenBlacklisted(String token) {
-        return redisTemplate.hasKey("access_" + token);
+        return redisTemplate.hasKey("access:" + token);
     }
 
     // Refresh Token 블랙리스트 확인
     public boolean isRefreshTokenBlacklisted(String token) {
-        return redisTemplate.hasKey("refresh_" + token);
+        return redisTemplate.hasKey("refresh:" + token);
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

**회원 비활성화 기능 수정 및 Redis 연동 개선**

## #️⃣ 연관된 이슈

#435 

## 📋 작업 내용
- 기존 JWTFilter에서 회원 비활성화 여부를 DB 에서 조회하던 기능을 Redis를 통해 조회하도록 수정
- `RedisConnectionCheckService`를 이용해 Redis 상태 체크 기능 추가
- 회원 비활성화 시 Redis 1번 저장소(`inactive:member:{memberId}`)에 데이터 저장
- 회원 활성화 시 해당 회원 ID를 Redis 1번 저장소에서 제거
- `JWTFilter`에서 비활성 회원 여부 확인 후 자동 로그아웃 처리
- `@RequiredArgsConstructor` 적용하여 코드 리팩토링
- 
## ✅ 테스트 및 확인 사항
- [ ] 비활성화된 회원이 로그인 시 차단되는지 확인
- [ ] 활성화된 회원이 정상적으로 로그인되는지 확인
- [ ] Redis 연결이 끊겼을 때 정상적으로 처리되는지 확인
