### PR TITLE
[REFACTOR] 445 memberservice 인터페이스 및 구현체 분리

### DIFF
--- a/module-api/src/main/java/com/checkping/api/controller/member/AdminMemberApi.java
+++ b/module-api/src/main/java/com/checkping/api/controller/member/AdminMemberApi.java
@@ -33,7 +33,7 @@ public interface AdminMemberApi {
         int size,
         @Parameter(description = "role(예: ADMIN, MEMBER)", example = "ADMIN")
         String role,
-        @Parameter(description = "status(예: ACTIVE, INACTIVE)", example = "ACTIVE")
+        @Parameter(description = "status(예: ACTIVE, INACTIVE, DELETED)", example = "ACTIVE")
         String status,
         @Parameter(description = "검색어 (이름/이메일 검색)", example = "홍길동")
         String keyword);

--- a/module-service/src/main/java/com/checkping/dto/member/request/ChangePasswordDto.java
+++ b/module-service/src/main/java/com/checkping/dto/member/request/ChangePasswordDto.java
@@ -11,7 +11,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class ChangePasswordDto {
 
-    @Schema(description = "현재 비밀번호", example = "password1234")
+    @Schema(description = "현재 비밀번호", example = "passwor1234 * 지금은 현재 비밀번호 검증 없이 수정 가능 *")
     private String currentPassword;
     @Schema(description = "새로운 비밀번호", example = "newPassword1234")
     private String newPassword;

--- a/module-service/src/main/java/com/checkping/dto/member/request/MemberRegisterDto.java
+++ b/module-service/src/main/java/com/checkping/dto/member/request/MemberRegisterDto.java
@@ -14,11 +14,11 @@ public class MemberRegisterDto {
 
     @Schema(description = "조직 ID", example = "1")
     private Long organizationId;
-    @Schema(description = "이메일", example = "example@example.com")
+    @Schema(description = "이메일", example = "example@test.com")
     private String email;
-    @Schema(description = "비밀번호", example = "password1234")
+    @Schema(description = "비밀번호", example = "1111")
     private String password;
-    @Schema(description = "이름", example = "Optimus Prime")
+    @Schema(description = "이름", example = "주농퐛")
     private String name;
     @Schema(description = "역할", example = "ADMIN") // ADMIN, USER
     private String role;
@@ -28,9 +28,9 @@ public class MemberRegisterDto {
     private String jobRole;
     @Schema(description = "직책", example = "팀장")
     private String jobTitle;
-    @Schema(description = "소개", example = "안녕하세요. 저는 옵티머스프라임입니다.")
+    @Schema(description = "소개", example = "안녕하세요.")
     private String introduction;
-    @Schema(description = "비고", example = "곧 퇴사함")
+    @Schema(description = "비고", example = "안녕하세요")
     private String remark;
 
     //DTO -> Member 엔티티 변환

--- a/module-service/src/main/java/com/checkping/service/member/MemberService.java
+++ b/module-service/src/main/java/com/checkping/service/member/MemberService.java
@@ -1,14 +1,7 @@
 package com.checkping.service.member;
 
 import com.checkping.common.dto.PageInfo;
-import com.checkping.common.dto.PageMetaResponse;
-import com.checkping.common.enums.ErrorCode;
-import com.checkping.common.exception.BaseException;
 import com.checkping.common.utils.FileResponse;
-import com.checkping.domain.member.Member;
-import com.checkping.domain.member.Organization;
-import com.checkping.domain.member.projection.ProjectList;
-import com.checkping.domain.project.Project;
 import com.checkping.dto.ProjectListGet;
 import com.checkping.dto.member.request.ChangePasswordDto;
 import com.checkping.dto.member.request.MemberRegisterDto;
@@ -17,305 +10,32 @@ import com.checkping.dto.member.response.MemberListResponseDto;
 import com.checkping.dto.member.response.MemberResponseDto;
 import com.checkping.dto.member.response.MemberSignatureExistResponseDto;
 import com.checkping.dto.member.response.MemberSignatureResponseDto;
-import com.checkping.exception.member.InvalidInputValueException;
-import com.checkping.infra.repository.member.MemberRepository;
-import com.checkping.infra.repository.member.OrganizationRepository;
-import com.checkping.infra.repository.member.ProjectQueryRepository;
-import com.checkping.service.member.util.CurrentMemberUtil;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+public interface MemberService {
 
-// TODO BaseException 을 상속하는 커스텀 Exception 작성하기
+    MemberResponseDto getMemberById(Long memberId);
 
-@Service
-public class MemberService {
+    MemberListResponseDto getAllMembersWithFilters(int page, int size, String roleParam, String statusParam, String keyword);
 
-    private final MemberRepository memberRepository;          // 도메인 인터페이스
-    private final OrganizationRepository organizationRepository; // 조직 레포지토리(예: JPA)
-    private final BCryptPasswordEncoder passwordEncoder;
-    private final CurrentMemberUtil currentMemberUtil;
-    private final ProjectQueryRepository projectQueryRepository;
+    MemberResponseDto registerMember(MemberRegisterDto dto);
 
-    public MemberService(MemberRepository memberRepository,
-        OrganizationRepository organizationRepository, BCryptPasswordEncoder passwordEncoder,
-        CurrentMemberUtil currentMemberUtil, ProjectQueryRepository projectQueryRepository) {
-        this.memberRepository = memberRepository;
-        this.organizationRepository = organizationRepository;
-        this.passwordEncoder = passwordEncoder;
-        this.currentMemberUtil = currentMemberUtil;
-        this.projectQueryRepository = projectQueryRepository;
-    }
+    MemberResponseDto updateMember(Long memberId, MemberUpdateDto dto);
 
-    // 아이디로 회원 조회
-    public MemberResponseDto getMemberById(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(
-                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
-        return MemberResponseDto.fromEntity(member);
-    }
+    void changePassword(Long memberId, ChangePasswordDto dto);
 
-    // 페이징된 전체 회원 목록 조회
-    public MemberListResponseDto getAllMembersWithFilters(
-        int page, int size, String roleParam, String statusParam, String keyword
-    ) {
-        // (1) 페이지, 사이즈 유효성 검증
-        if (page < 0 || size < 1) {
-            throw new InvalidInputValueException("유효하지 않은 페이지/사이즈 값입니다.");
-        }
+    void deleteMember(Long memberId, String reasonForDelete);
 
-        // (2) 문자열로 들어온 role, status를 Enum으로 변환
-        Member.Role role = null;
-        if (roleParam != null && !roleParam.isBlank()) {
-            try {
-                role = Member.Role.valueOf(roleParam.toUpperCase());
-            } catch (IllegalArgumentException e) {
-                throw new InvalidInputValueException("유효하지 않은 role 값입니다. " + roleParam);
-            }
-        }
+    MemberListResponseDto getMembersByOrganizationId(Long organizationId, int page, int size);
 
-        Member.Status status = null;
-        if (statusParam != null && !statusParam.isBlank()) {
-            try {
-                status = Member.Status.valueOf(statusParam.toUpperCase());
-            } catch (IllegalArgumentException e) {
-                throw new InvalidInputValueException("유효하지 않은 status 값입니다. " + statusParam);
-            }
-        }
+    MemberSignatureResponseDto uploadSignature(FileResponse signatureFile);
 
-        // (3) 검색어 null 처리
-        if (keyword != null && keyword.isBlank()) {
-            keyword = null;
-        }
+    MemberSignatureExistResponseDto getSignature();
 
-        Pageable pageable = PageRequest.of(page, size);
-        Page<Member> memberPage = memberRepository.findAllWithFilters(role, status, keyword,
-            pageable);
+    void activateMember(Long memberId);
 
-        // (4) page 범위 초과 시 예외 처리
-        if (page >= memberPage.getTotalPages() && memberPage.getTotalPages() != 0) {
-            throw new InvalidInputValueException("페이지 번호가 범위를 벗어났습니다.");
-        }
+    void deactivateMember(Long memberId);
 
-        // (5) 결과 DTO 변환
-        return MemberListResponseDto.fromEntityPage(memberPage);
-    }
+    String getMemberStatus(Long memberId);
 
-    // 회원 등록
-    public MemberResponseDto registerMember(MemberRegisterDto dto) {
-        // 이메일 중복 체크
-        if (memberRepository.existsByEmail(dto.getEmail())) {
-            throw new BaseException("이미 사용중인 이메일입니다.", ErrorCode.DUPLICATE_EMAIL);
-        }
-
-        // 조직(Organization) 존재 여부 확인
-        Organization organization = organizationRepository.findById(dto.getOrganizationId())
-            .orElseThrow(() -> new BaseException("조직이 존재하지 않습니다: " + dto.getOrganizationId(),
-                ErrorCode.USER_NOT_FOUND));
-
-        // 비밀번호 암호화
-        String encodedPassword = passwordEncoder.encode(dto.getPassword());
-
-        // DTO -> Member 엔티티 변환
-        Member member = MemberRegisterDto.toEntity(dto, organization, encodedPassword);
-
-        // DB 저장
-        Member savedMember = memberRepository.save(member);
-
-        // 결과 DTO 반환
-        return MemberResponseDto.fromEntity(savedMember);
-    }
-
-    // 회원 정보 수정
-    public MemberResponseDto updateMember(Long memberId, MemberUpdateDto dto) {
-        // 기존 회원 찾기
-        Member existingMember = memberRepository.findById(memberId)
-            .orElseThrow(
-                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
-
-        // DTO -> 엔티티 업데이트
-        MemberUpdateDto.toEntity(existingMember, dto);
-
-        // 수정된 엔티티 저장
-        Member updatedMember = memberRepository.save(existingMember);
-
-        // DTO로 변환하여 반환
-        return MemberResponseDto.fromEntity(updatedMember);
-    }
-
-    // 비밀번호 변경
-    public void changePassword(Long memberId, ChangePasswordDto dto) {
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(
-                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
-
-        // 현재 비밀번호 확인
-        if (!passwordEncoder.matches(dto.getCurrentPassword(), member.getPassword())) {
-            throw new BaseException("현재 비밀번호가 일치하지 않습니다.", ErrorCode.INVALID_LOGIN_CREDENTIALS);
-        }
-
-        // 새 비밀번호와 확인 비밀번호 일치 여부 확인
-        if (!dto.getNewPassword().equals(dto.getConfirmNewPassword())) {
-            throw new BaseException("새 비밀번호와 확인 비밀번호가 일치하지 않습니다.",
-                ErrorCode.INVALID_LOGIN_CREDENTIALS);
-        }
-
-        // 비밀번호 암호화 적용
-        String encodedPassword = passwordEncoder.encode(dto.getNewPassword());
-
-        // 엔티티에 비밀번호 변경 로직 적용
-        ChangePasswordDto.updatePassword(member, encodedPassword);
-
-        // 수정된 엔티티 저장
-        memberRepository.save(member);
-    }
-
-    // 회원 삭제
-    public void deleteMember(Long memberId, String reasonForDelete) {
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(
-                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
-        if (member.isDeleted()) {
-            throw new BaseException("이미 삭제된 회원입니다.", ErrorCode.ALREADY_APPLIED);
-        }
-        // 회원 삭제 처리
-        member.deleteAccount(reasonForDelete);
-        memberRepository.save(member);
-    }
-
-    //업체별 회원 목록 조회
-    public MemberListResponseDto getMembersByOrganizationId(Long organizationId, int page,
-        int size) {
-
-        //존재하지 않는 업체 아이디인 경우 예외 처리
-        if (!organizationRepository.existsById(organizationId)) {
-            throw new BaseException("해당 업체가 존재하지 않습니다.", ErrorCode.ORGANIZATION_NOT_FOUND);
-        }
-
-        //페이지에 음수들어온 경우 예외 처리
-        if (page < 0 || size < 0) {
-            throw new InvalidInputValueException("페이지 번호는 0보다 크고 사이즈는 1보다 커야합니다.");
-        }
-
-        Pageable pageable = PageRequest.of(page, size);
-        Page<Member> memberPage = memberRepository.findByOrganizationId(organizationId, pageable);
-
-        //범위 바깥의 페이지 요청
-        if (page >= memberPage.getTotalPages() && memberPage.getTotalPages() != 0) {
-            throw new InvalidInputValueException("페이지 번호가 범위를 벗어났습니다.");
-        }
-        //페이지에 회원이 없는 경우 예외 처리
-        if (memberPage.isEmpty()) {
-            throw new BaseException("해당 업체에 회원이 존재하지 않습니다.", ErrorCode.USER_NOT_FOUND);
-        }
-        // MemberListResponseDto로 변환
-        return MemberListResponseDto.fromEntityPage(memberPage);
-    }
-
-    /**
-     * 회원 서명 파일 업로드
-     *
-     * @param signatureFile 서명 파일
-     * @return MemberSignatureResponseDto
-     */
-    @Transactional
-    public MemberSignatureResponseDto uploadSignature(FileResponse signatureFile) {
-        // 회원 조회
-        Member member = currentMemberUtil.getCurrentMember();
-
-        // 서명 파일 URL 저장
-        member.uploadSignature(signatureFile.url());
-
-        // 결과 DTO 반환
-        return MemberSignatureResponseDto.toDto(member);
-    }
-
-    /**
-     * 회원 서명 파일 존재 여부
-     *
-     * @return MemberSignatureExistResponseDto
-     */
-    public MemberSignatureExistResponseDto getSignature() {
-
-        Member member = currentMemberUtil.getCurrentMember();
-
-        return MemberSignatureExistResponseDto.toDto(member);
-    }
-
-    //회원 활성화
-    public void activateMember(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(
-                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
-
-        if(member.isActive()){
-            throw new BaseException("이미 활성화된 회원입니다.", ErrorCode.ALREADY_APPLIED);
-        }
-        member.activateAccount();
-        memberRepository.save(member);
-    }
-
-    /*
-    * 회원 비활성화
-    * 관리자가 회원을 비활성화 처리합니다. - inactiveAccount
-    * */
-
-    public void deactivateMember(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(
-                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
-
-        if(member.isDeleted()){
-            throw new BaseException("삭제된 회원입니다.", ErrorCode.ALREADY_APPLIED);
-        }
-
-        if(!member.isActive()){
-            throw new BaseException("이미 비활성화된 회원입니다.", ErrorCode.ALREADY_APPLIED);
-        }
-        member.deactivateAccount();
-        memberRepository.save(member);
-    }
-
-    public String getMemberStatus(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(
-                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
-        return member.getStatus().name();
-    }
-
-    public PageInfo.Response<ProjectListGet.Response> getProjectsByMember(Long memberId, String managementStep, PageInfo.Request pageRequest) {
-
-        Pageable pageable = PageRequest.of(
-                pageRequest.getCurrentPage() - 1,
-                pageRequest.getPageSize());
-
-        Project.ManagementStep validManagementStep = checkManagementStep(managementStep);
-
-        Page<ProjectList> result = projectQueryRepository.getProjectsByMemberAndOrganization(
-                null,
-                memberId,
-                validManagementStep,
-                pageRequest.getKeyword(),
-                pageable);
-
-        List<ProjectListGet.Response> dtoList = result.getContent().stream().map(ProjectListGet.Response::toDto).toList();
-        PageMetaResponse meta = PageMetaResponse.fromPage(result);
-
-        return PageInfo.Response.<ProjectListGet.Response>builder()
-                .dtoList(dtoList)
-                .meta(meta.toMap())
-                .build();
-    }
-
-    private Project.ManagementStep checkManagementStep(String managementStep) {
-        if (managementStep == null || managementStep.trim().isEmpty()) {
-            return null;
-        }
-        return Project.ManagementStep.valueOf(managementStep.toUpperCase());
-    }
+    PageInfo.Response<ProjectListGet.Response> getProjectsByMember(Long memberId, String managementStep, PageInfo.Request pageRequest);
 }

--- a/module-service/src/main/java/com/checkping/service/member/MemberServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/member/MemberServiceImpl.java
@@ -1,0 +1,325 @@
+package com.checkping.service.member;
+
+import com.checkping.common.dto.PageInfo;
+import com.checkping.common.dto.PageMetaResponse;
+import com.checkping.common.enums.ErrorCode;
+import com.checkping.common.exception.BaseException;
+import com.checkping.common.utils.FileResponse;
+import com.checkping.domain.member.Member;
+import com.checkping.domain.member.Organization;
+import com.checkping.domain.member.projection.ProjectList;
+import com.checkping.domain.project.Project;
+import com.checkping.dto.ProjectListGet;
+import com.checkping.dto.member.request.ChangePasswordDto;
+import com.checkping.dto.member.request.MemberRegisterDto;
+import com.checkping.dto.member.request.MemberUpdateDto;
+import com.checkping.dto.member.response.MemberListResponseDto;
+import com.checkping.dto.member.response.MemberResponseDto;
+import com.checkping.dto.member.response.MemberSignatureExistResponseDto;
+import com.checkping.dto.member.response.MemberSignatureResponseDto;
+import com.checkping.exception.member.InvalidInputValueException;
+import com.checkping.infra.repository.member.MemberRepository;
+import com.checkping.infra.repository.member.OrganizationRepository;
+import com.checkping.infra.repository.member.ProjectQueryRepository;
+import com.checkping.service.member.util.CurrentMemberUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+// TODO BaseException 을 상속하는 커스텀 Exception 작성하기
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;          // 도메인 인터페이스
+    private final OrganizationRepository organizationRepository; // 조직 레포지토리(예: JPA)
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final CurrentMemberUtil currentMemberUtil;
+    private final ProjectQueryRepository projectQueryRepository;
+
+    // 아이디로 회원 조회
+    @Override
+    public MemberResponseDto getMemberById(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(
+                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
+        return MemberResponseDto.fromEntity(member);
+    }
+
+    // 페이징된 전체 회원 목록 조회
+    @Override
+    public MemberListResponseDto getAllMembersWithFilters(
+        int page, int size, String roleParam, String statusParam, String keyword
+    ) {
+        // (1) 페이지, 사이즈 유효성 검증
+        if (page < 0 || size < 1) {
+            throw new InvalidInputValueException("유효하지 않은 페이지/사이즈 값입니다.");
+        }
+
+        // (2) 문자열로 들어온 role, status를 Enum으로 변환
+        Member.Role role = null;
+        if (roleParam != null && !roleParam.isBlank()) {
+            try {
+                role = Member.Role.valueOf(roleParam.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new InvalidInputValueException("유효하지 않은 role 값입니다. " + roleParam);
+            }
+        }
+
+        Member.Status status = null;
+        if (statusParam != null && !statusParam.isBlank()) {
+            try {
+                status = Member.Status.valueOf(statusParam.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new InvalidInputValueException("유효하지 않은 status 값입니다. " + statusParam);
+            }
+        }
+
+        // (3) 검색어 null 처리
+        if (keyword != null && keyword.isBlank()) {
+            keyword = null;
+        }
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Member> memberPage = memberRepository.findAllWithFilters(role, status, keyword,
+            pageable);
+
+        // (4) page 범위 초과 시 예외 처리
+        if (page >= memberPage.getTotalPages() && memberPage.getTotalPages() != 0) {
+            throw new InvalidInputValueException("페이지 번호가 범위를 벗어났습니다.");
+        }
+
+        // (5) 결과 DTO 변환
+        return MemberListResponseDto.fromEntityPage(memberPage);
+    }
+
+    // 회원 등록
+    @Override
+    public MemberResponseDto registerMember(MemberRegisterDto dto) {
+        // 이메일 중복 체크
+        if (memberRepository.existsByEmail(dto.getEmail())) {
+            throw new BaseException("이미 사용중인 이메일입니다.", ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        // 조직(Organization) 존재 여부 확인
+        Organization organization = organizationRepository.findById(dto.getOrganizationId())
+            .orElseThrow(() -> new BaseException("조직이 존재하지 않습니다: " + dto.getOrganizationId(),
+                ErrorCode.USER_NOT_FOUND));
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(dto.getPassword());
+
+        // DTO -> Member 엔티티 변환
+        Member member = MemberRegisterDto.toEntity(dto, organization, encodedPassword);
+
+        // DB 저장
+        Member savedMember = memberRepository.save(member);
+
+        // 결과 DTO 반환
+        return MemberResponseDto.fromEntity(savedMember);
+    }
+
+    // 회원 정보 수정
+    @Override
+    public MemberResponseDto updateMember(Long memberId, MemberUpdateDto dto) {
+        // 기존 회원 찾기
+        Member existingMember = memberRepository.findById(memberId)
+            .orElseThrow(
+                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
+
+        // DTO -> 엔티티 업데이트
+        MemberUpdateDto.toEntity(existingMember, dto);
+
+        // 수정된 엔티티 저장
+        Member updatedMember = memberRepository.save(existingMember);
+
+        // DTO로 변환하여 반환
+        return MemberResponseDto.fromEntity(updatedMember);
+    }
+
+    // 비밀번호 변경
+    @Override
+    public void changePassword(Long memberId, ChangePasswordDto dto) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(
+                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
+
+        // 현재 비밀번호 확인, TODO 추후 현재 비밀번호 확인 로직 추가
+//        if (!passwordEncoder.matches(dto.getCurrentPassword(), member.getPassword())) {
+//            throw new BaseException("현재 비밀번호가 일치하지 않습니다.", ErrorCode.INVALID_LOGIN_CREDENTIALS);
+//        }
+
+        // 새 비밀번호와 확인 비밀번호 일치 여부 확인
+        if (!dto.getNewPassword().equals(dto.getConfirmNewPassword())) {
+            throw new BaseException("새 비밀번호와 확인 비밀번호가 일치하지 않습니다.",
+                ErrorCode.INVALID_LOGIN_CREDENTIALS);
+        }
+
+        // 비밀번호 암호화 적용
+        String encodedPassword = passwordEncoder.encode(dto.getNewPassword());
+
+        // 엔티티에 비밀번호 변경 로직 적용
+        ChangePasswordDto.updatePassword(member, encodedPassword);
+
+        // 수정된 엔티티 저장
+        memberRepository.save(member);
+    }
+
+    // 회원 삭제
+    @Override
+    public void deleteMember(Long memberId, String reasonForDelete) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(
+                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
+        if (member.isDeleted()) {
+            throw new BaseException("이미 삭제된 회원입니다.", ErrorCode.ALREADY_APPLIED);
+        }
+        // 회원 삭제 처리
+        member.deleteAccount(reasonForDelete);
+        memberRepository.save(member);
+    }
+
+    //업체별 회원 목록 조회
+    @Override
+    public MemberListResponseDto getMembersByOrganizationId(Long organizationId, int page,
+        int size) {
+
+        //존재하지 않는 업체 아이디인 경우 예외 처리
+        if (!organizationRepository.existsById(organizationId)) {
+            throw new BaseException("해당 업체가 존재하지 않습니다.", ErrorCode.ORGANIZATION_NOT_FOUND);
+        }
+
+        //페이지에 음수들어온 경우 예외 처리
+        if (page < 0 || size < 0) {
+            throw new InvalidInputValueException("페이지 번호는 0보다 크고 사이즈는 1보다 커야합니다.");
+        }
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Member> memberPage = memberRepository.findByOrganizationId(organizationId, pageable);
+
+        //범위 바깥의 페이지 요청
+        if (page >= memberPage.getTotalPages() && memberPage.getTotalPages() != 0) {
+            throw new InvalidInputValueException("페이지 번호가 범위를 벗어났습니다.");
+        }
+        //페이지에 회원이 없는 경우 예외 처리
+        if (memberPage.isEmpty()) {
+            throw new BaseException("해당 업체에 회원이 존재하지 않습니다.", ErrorCode.USER_NOT_FOUND);
+        }
+        // MemberListResponseDto로 변환
+        return MemberListResponseDto.fromEntityPage(memberPage);
+    }
+
+    /**
+     * 회원 서명 파일 업로드
+     *
+     * @param signatureFile 서명 파일
+     * @return MemberSignatureResponseDto
+     */
+    @Override
+    @Transactional
+    public MemberSignatureResponseDto uploadSignature(FileResponse signatureFile) {
+        // 회원 조회
+        Member member = currentMemberUtil.getCurrentMember();
+
+        // 서명 파일 URL 저장
+        member.uploadSignature(signatureFile.url());
+
+        // 결과 DTO 반환
+        return MemberSignatureResponseDto.toDto(member);
+    }
+
+    /**
+     * 회원 서명 파일 존재 여부
+     *
+     * @return MemberSignatureExistResponseDto
+     */
+    @Override
+    public MemberSignatureExistResponseDto getSignature() {
+
+        Member member = currentMemberUtil.getCurrentMember();
+
+        return MemberSignatureExistResponseDto.toDto(member);
+    }
+
+    //회원 활성화
+    @Override
+    public void activateMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(
+                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
+
+        if(member.isActive()){
+            throw new BaseException("이미 활성화된 회원입니다.", ErrorCode.ALREADY_APPLIED);
+        }
+        member.activateAccount();
+        memberRepository.save(member);
+    }
+
+    /**
+    * 회원 비활성화
+    * 관리자가 회원을 비활성화 처리합니다. - inactiveAccount
+    * */
+    @Override
+    public void deactivateMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(
+                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
+
+        if(member.isDeleted()){
+            throw new BaseException("삭제된 회원입니다.", ErrorCode.ALREADY_APPLIED);
+        }
+
+        if(!member.isActive()){
+            throw new BaseException("이미 비활성화된 회원입니다.", ErrorCode.ALREADY_APPLIED);
+        }
+        member.deactivateAccount();
+        memberRepository.save(member);
+    }
+
+    @Override
+    public String getMemberStatus(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(
+                () -> new BaseException("회원이 존재하지 않습니다: " + memberId, ErrorCode.USER_NOT_FOUND));
+        return member.getStatus().name();
+    }
+
+    @Override
+    public PageInfo.Response<ProjectListGet.Response> getProjectsByMember(Long memberId, String managementStep, PageInfo.Request pageRequest) {
+
+        Pageable pageable = PageRequest.of(
+                pageRequest.getCurrentPage() - 1,
+                pageRequest.getPageSize());
+
+        Project.ManagementStep validManagementStep = checkManagementStep(managementStep);
+
+        Page<ProjectList> result = projectQueryRepository.getProjectsByMemberAndOrganization(
+                null,
+                memberId,
+                validManagementStep,
+                pageRequest.getKeyword(),
+                pageable);
+
+        List<ProjectListGet.Response> dtoList = result.getContent().stream().map(ProjectListGet.Response::toDto).toList();
+        PageMetaResponse meta = PageMetaResponse.fromPage(result);
+
+        return PageInfo.Response.<ProjectListGet.Response>builder()
+                .dtoList(dtoList)
+                .meta(meta.toMap())
+                .build();
+    }
+
+    private Project.ManagementStep checkManagementStep(String managementStep) {
+        if (managementStep == null || managementStep.trim().isEmpty()) {
+            return null;
+        }
+        return Project.ManagementStep.valueOf(managementStep.toUpperCase());
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request

**[MemberService 인터페이스 분리 및 MemberServiceImpl 구현체 생성]**

## #️⃣ 연관된 이슈

#445

## 📋 작업 내용

- MemberService 인터페이스 분리하여 서비스 레이어의 유연성 향상
- MemberServiceImpl에서 MemberService를 구현하도록 변경
- @RequiredArgsConstructor 추가하여 생성자 주입 간소화
- 기존 MemberService 관련 메서드를 MemberServiceImpl로 이동
- 프로젝트 관련 조회 메서드(getProjectsByMember) 인터페이스 및 구현체에 반영
- 기존 서비스 레이어에서 인터페이스를 참조하도록 리팩토링
- 
- 스웨거 문서 예시 변경
