### PR TITLE
Error/456  403에러 응답 본문 누락 문제

### DIFF
--- a/module-api/src/main/java/com/checkping/api/auth/config/CustomSecurityConfig.java
+++ b/module-api/src/main/java/com/checkping/api/auth/config/CustomSecurityConfig.java
@@ -2,6 +2,7 @@ package com.checkping.api.auth.config;
 
 import com.checkping.api.auth.filter.JWTFilter;
 import com.checkping.api.exceptionhandler.CustomAccessDeniedHandler;
+import com.checkping.api.exceptionhandler.CustomAuthenticationEntryPoint;
 import com.checkping.service.member.auth.RedisConnectionCheckService;
 import com.checkping.service.member.auth.TokenBlacklistService;
 import com.checkping.service.member.util.JwtUtil;
@@ -37,6 +38,7 @@ public class CustomSecurityConfig {
     private final JwtUtil jwtUtil;
     private final TokenBlacklistService tokenBlacklistService;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final StringRedisTemplate redisTemplateForInactiveMembers;
     private final RedisConnectionCheckService redisConnectionCheckService;
 
@@ -77,6 +79,8 @@ public class CustomSecurityConfig {
                 .anyRequest().authenticated());
 
         http.exceptionHandling((exception) -> exception.accessDeniedHandler(customAccessDeniedHandler));
+
+        http.exceptionHandling((exception) -> exception.authenticationEntryPoint(customAuthenticationEntryPoint));
 
         http.addFilterBefore(new JWTFilter(jwtUtil,tokenBlacklistService, redisTemplateForInactiveMembers, redisConnectionCheckService), UsernamePasswordAuthenticationFilter.class);
 

--- a/module-api/src/main/java/com/checkping/api/exceptionhandler/CustomAccessDeniedHandler.java
+++ b/module-api/src/main/java/com/checkping/api/exceptionhandler/CustomAccessDeniedHandler.java
@@ -1,17 +1,20 @@
 package com.checkping.api.exceptionhandler;
 
-import com.checkping.common.response.BaseResponse;
 import com.checkping.common.enums.ErrorCode;
+import com.checkping.common.response.BaseResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
+//권한이 없는 요청을 할 경우 403 Forbidden 에러 처리
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -19,6 +22,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException {
+        log.error("Access Denied Handler : {}", accessDeniedException.getMessage());
         response.setContentType("application/json");
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setCharacterEncoding("UTF-8");

--- a/module-api/src/main/java/com/checkping/api/exceptionhandler/CustomAuthenticationEntryPoint.java
+++ b/module-api/src/main/java/com/checkping/api/exceptionhandler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,48 @@
+package com.checkping.api.exceptionhandler;
+
+import com.checkping.common.enums.ErrorCode;
+import com.checkping.common.response.BaseResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+// 인증 실패 시 401 에러 처리하는 클래스
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException)
+            throws IOException, ServletException {
+        log.error("Authentication Entry Point : {}", authException.getMessage());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
+        String message = "인증이 필요합니다.";
+
+        // JWT 만료 예외가 발생한 경우 메시지를 변경
+        Throwable cause = authException.getCause();
+        if (cause instanceof ExpiredJwtException) {
+            errorCode = ErrorCode.EXPIRED_JWT_ACCESS_TOKEN; // 새로운 에러 코드 추가 가능
+            message = "토큰이 만료되었습니다. 다시 로그인하세요.";
+        }
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        BaseResponse<?> errorResponse = BaseResponse.fail(message, errorCode);
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request

feat: AccessDeniedHandler에 로깅 추가
feat: 인증 실패 시 JWT 만료 예외 처리 및 메시지 개선
feat: CustomAuthenticationEntryPoint 추가 및 Security 설정 개선

## #️⃣ 연관된 이슈

#456 

## 📋 작업 내용

- CustomAccessDeniedHandler에 @Slf4j 어노테이션 추가
- 권한이 없는 요청 발생 시 로그 기록 (`AccessDeniedException` 메시지 포함)

- CustomAuthenticationEntryPoint에서 JWT 만료 (`ExpiredJwtException`) 감지 로직 추가
- 토큰 만료 시 `ErrorCode.EXPIRED_JWT_ACCESS_TOKEN` 반환 및 메시지 변경
- 기본 인증 실패 메시지를 "인증이 필요합니다."로 설정
- 응답을 JSON 형식으로 반환하도록 개선
- 
- CustomSecurityConfig에 CustomAuthenticationEntryPoint 추가
- 인증 실패 시 CustomAuthenticationEntryPoint에서 처리하도록 설정
- http.exceptionHandling(authenticationEntryPoint) 추가
