### PR TITLE
chore: 회원 활성화 로직 수정

### DIFF
--- a/module-domain/src/main/java/com/checkping/domain/member/Member.java
+++ b/module-domain/src/main/java/com/checkping/domain/member/Member.java
@@ -147,12 +147,16 @@ public class Member extends BaseEntity {
     public void deleteAccount(String reason) {
         this.deleteAccountAt = LocalDateTime.now();
         this.reasonForDeleteAccount = reason;
+        this.remark = "회원 탈퇴됨 : " + LocalDate.now();
         this.status = Status.DELETED;
     }
 
     //회원 활성화
     public void activateAccount() {
-        this.reasonForDeleteAccount = "회원 재활성화됨 : " + LocalDate.now();
+        if (this.reasonForDeleteAccount != null && !this.reasonForDeleteAccount.isEmpty()) {
+            this.reasonForDeleteAccount = null;
+        }
+        this.remark = "회원 재활성화됨 : " + LocalDate.now();
         this.status = Status.ACTIVE;
     }
 


### PR DESCRIPTION
# 🚀 Pull Request

chore: 회원 활성화 로직 수정

## #️⃣ 연관된 이슈

#476 

## 📋 작업 내용

- 회원 활성화 시 reasonForDeleteAccount 값이 존재할 경우에만 null 처리
- remark 필드에 "회원 재활성화됨" 정보 추가