### PR TITLE
Feature/493 삭제된 회원이 요청 보낼 수 없도록 하는 기능추가

### DIFF
--- a/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
@@ -67,12 +67,13 @@ public class JWTFilter extends OncePerRequestFilter {
 
             // 요청한 Access Token이 블랙리스트에 등록된 토큰인지 확인
             if (tokenBlacklistService.isAccessTokenBlacklisted(accessToken)) {
-                throw new AuthenticationException("블랙리스트에 등록된 토큰입니다.");
+                throw new AuthenticationException("블랙리스트에 등록된 토큰입니다. 요청된 토큰 발급회원 id: " + id);
             }
 
-            // 요청한 access token의 id가 비활성화된 회원인지 확인
+            // 요청한 access token의 id가 비활성화되었거나 삭제된 회원인지 확인
             Boolean isInactive = redisTemplateForInactiveMembers.hasKey("inactive:member:" + id);
-            if (Boolean.TRUE.equals(isInactive)) {
+            Boolean isDeleted = redisTemplateForInactiveMembers.hasKey("deleted:member:" + id);
+            if (Boolean.TRUE.equals(isInactive) || Boolean.TRUE.equals(isDeleted)) {
                 // 비활성화된 회원이 보낸 토큰을 블랙리스트에 추가
                 tokenBlacklistService.blacklistAccessToken(accessToken, jwtUtil.getExpiration(accessToken));
                 // 리프레시 토큰도 블랙리스트에 추가
@@ -84,7 +85,7 @@ public class JWTFilter extends OncePerRequestFilter {
                 response.addCookie(delAccess);
                 response.addCookie(delRefresh);
 
-                throw new AuthenticationException("비활성화된 회원입니다.");
+                throw isInactive ? new AuthenticationException("비활성화된 회원입니다. 요청된 토큰 발급회원 id: " + id) : new AuthenticationException("삭제된 회원입니다. 요청된 토큰 발급회원 id: " + id);
             }
         }
 

--- a/module-api/src/main/java/com/checkping/api/controller/member/AdminMemberController.java
+++ b/module-api/src/main/java/com/checkping/api/controller/member/AdminMemberController.java
@@ -1,12 +1,5 @@
 package com.checkping.api.controller.member;
 
-import static com.checkping.common.enums.SuccessCode.MEMBER_ACTIVATE;
-import static com.checkping.common.enums.SuccessCode.MEMBER_CHANGE_PASSWORD;
-import static com.checkping.common.enums.SuccessCode.MEMBER_DEACTIVATE;
-import static com.checkping.common.enums.SuccessCode.MEMBER_DELETE;
-import static com.checkping.common.enums.SuccessCode.MEMBER_REGISTER;
-import static com.checkping.common.enums.SuccessCode.MEMBER_UPDATE;
-
 import com.checkping.common.dto.PageInfo;
 import com.checkping.common.response.BaseResponse;
 import com.checkping.dto.ProjectListGet;
@@ -17,18 +10,19 @@ import com.checkping.dto.member.response.MemberListResponseDto;
 import com.checkping.dto.member.response.MemberResponseDto;
 import com.checkping.service.member.MemberService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import static com.checkping.common.enums.SuccessCode.*;
+
 
 @Tag(name = "어드민 회원 관리 API(AdminMemberApi)", description = "어드민 권한으로 회원을 관리할 수 있도록 하는 API입니다.")
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/admins/members")
 public class AdminMemberController implements AdminMemberApi {
 
     private final MemberService memberService;
-
-    public AdminMemberController(MemberService memberService) {
-        this.memberService = memberService;
-    }
 
     //keyword(예: 이름/이메일 검색)
     @GetMapping

--- a/module-service/src/main/java/com/checkping/service/member/MemberServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/member/MemberServiceImpl.java
@@ -34,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -218,6 +219,10 @@ public class MemberServiceImpl implements MemberService {
         // 회원 삭제 처리
         member.deleteAccount(reasonForDelete);
         memberRepository.save(member);
+        // Redis 1번 저장소에 탈퇴처리된 회원 ID 저장
+        if(redisConnectionCheckService.isRedisAvailable()){
+            redisTemplateForInactiveMemers.opsForValue().set("deleted:member:" + memberId, "true", 24, TimeUnit.HOURS);
+        }
     }
 
     //업체별 회원 목록 조회
@@ -305,6 +310,7 @@ public class MemberServiceImpl implements MemberService {
         // Redis 1번 저장소에 비활성화된 회원 ID 삭제
         if(redisConnectionCheckService.isRedisAvailable()){
             redisTemplateForInactiveMemers.delete("inactive:member:" + memberId);
+            redisTemplateForInactiveMemers.delete("deleted:member:" + memberId);
         }
     }
 


### PR DESCRIPTION
# 🚀 Pull Request

**[삭제된 회원이 JWTFilter를 통과하지 못하도록 검증 로직을 추가하였습니다.]**

## #️⃣ 연관된 이슈

#493

## 📋 작업 내용
	•	Redis에서 deleted:member 키를 조회하여 삭제된 회원 여부 검증 추가
	•	삭제된 회원이 요청 시 Access 및 Refresh 토큰을 블랙리스트에 등록 후 쿠키에서 제거
	•	예외 메시지에 요청한 토큰 발급 회원 ID 포함하여 디버깅 용이성 개선
