### PR TITLE
Feature/62 시스템 컬럼 생성자 수정자 id 인증기능 구현

### DIFF
--- a/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
@@ -90,6 +90,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         String name = jwtUtil.getName(accessToken);
         String email = jwtUtil.getEmail(accessToken);
+        request.setAttribute("email", email);
         String role = jwtUtil.getRole(accessToken);
 
         CustomUserDetails customUserDetails = new CustomUserDetails(id, name, email, role, "PASSWORDFORTOKEN");

--- a/module-common/src/main/java/com/checkping/common/config/AuditorAwareImpl.java
+++ b/module-common/src/main/java/com/checkping/common/config/AuditorAwareImpl.java
@@ -1,15 +1,32 @@
 package com.checkping.common.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Optional;
 
+@Slf4j
 @Component
 public class AuditorAwareImpl implements AuditorAware<String> {
+
+    public String getCurrentMemberEmail() {
+        Object email = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes())
+                .getRequest().getAttribute("email");
+
+        if (email instanceof String) {
+            return (String) email;
+        }
+
+        log.error("요청한 MemberId를 찾을 수 없습니다.");
+        return "Error : 요청한 회원의 MemberId를 찾을 수 없습니다.";
+    }
+
     @Override
     public Optional<String> getCurrentAuditor() {
-        String memberId = "testUserSystemColumn";
-        return Optional.of(memberId);
+        String memberEmail = getCurrentMemberEmail();
+        return Optional.of(memberEmail);
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

**[JWTFilter에서 이메일을 요청 속성으로 추가하여 이후 로직에서 활용 가능하도록 수정]**

## #️⃣ 연관된 이슈

#62

## 📋 작업 내용

	•	JWT에서 추출한 이메일을 request.setAttribute("email", email)로 저장
	•	AuditorAwareImpl에서 이메일 기반 감사자 정보를 가져올 수 있도록 변경 예정
	•	기존 인증 흐름에 영향 없이 SecurityContextHolder에 사용자 정보 설정 유지
