### PR TITLE
Feature/508 따닥 방지 구현 (Redis 상태 확인 후 중복 클릭 방지 인터셉터 등록)

### DIFF
--- a/module-api/src/main/java/com/checkping/api/auth/config/InterceptorMvcConfig.java
+++ b/module-api/src/main/java/com/checkping/api/auth/config/InterceptorMvcConfig.java
@@ -1,22 +1,32 @@
-//package com.checkping.api.auth.config;
-//
-//import com.checkping.api.auth.interceptor.ApprovalAuthorizationInterceptor;
-//import com.checkping.api.auth.interceptor.AuthInterceptor;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-//import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-//
-//@Configuration
-//@RequiredArgsConstructor
-//public class InterceptorMvcConfig implements WebMvcConfigurer {
-//
-//    private final AuthInterceptor authInterceptor;
-//    private final ApprovalAuthorizationInterceptor approvalAuthorizationInterceptor;
-//
-//    @Override
-//    public void addInterceptors(InterceptorRegistry registry) {
-//        registry.addInterceptor(authInterceptor);
-//        registry.addInterceptor(approvalAuthorizationInterceptor);
-//    }
-//}
+package com.checkping.api.auth.config;
+
+import com.checkping.api.auth.interceptor.DuplicatedClickPrevent;
+import com.checkping.service.member.auth.RedisConnectionCheckService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class InterceptorMvcConfig implements WebMvcConfigurer {
+
+    private final RedisConnectionCheckService redisConnectionCheckService;
+    private final DuplicatedClickPrevent duplicatedClickPrevent;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+
+        // Redis 서버가 정상적으로 작동 중일 때만 중복 클릭 방지 인터셉터를 등록
+        if(redisConnectionCheckService.isRedisAvailable()){
+            registry.addInterceptor(duplicatedClickPrevent)
+                    .addPathPatterns("/**") // 모든 경로에 인터셉터 적용, 예외 경로는 excludePathPatterns()로 설정
+                    .excludePathPatterns(
+                            "/login",
+                            "/reissue",
+                            "/swagger-ui/**",
+                            "/v3/api-docs/**"
+                    );
+        }
+    }
+}

--- a/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
+++ b/module-api/src/main/java/com/checkping/api/auth/filter/JWTFilter.java
@@ -62,6 +62,7 @@ public class JWTFilter extends OncePerRequestFilter {
         }
 
         Long id = jwtUtil.getMemberId(accessToken);
+        request.setAttribute("memberId", id);
 
         if (redisConnectionCheckService.isRedisAvailable()) {
 

--- a/module-api/src/main/java/com/checkping/api/auth/interceptor/DuplicatedClickPrevent.java
+++ b/module-api/src/main/java/com/checkping/api/auth/interceptor/DuplicatedClickPrevent.java
@@ -1,0 +1,59 @@
+package com.checkping.api.auth.interceptor;
+
+import com.checkping.exception.request.DuplicateRequestException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@Slf4j
+public class DuplicatedClickPrevent implements HandlerInterceptor {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private static final String PREFIX = "CLICK:ID:";
+
+    public DuplicatedClickPrevent(@Qualifier("redisTemplateForDuplicatedClick") StringRedisTemplate stringRedisTemplate) {
+        this.stringRedisTemplate = stringRedisTemplate;
+    }
+
+    public boolean checkAndSetRequest(String email) {
+        String key = PREFIX + email;
+        Boolean success = stringRedisTemplate.opsForValue()
+                .setIfAbsent(key, "LOCK", 3, TimeUnit.SECONDS);
+
+        return success != null && success;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String requestURI = request.getRequestURI();
+        String method = request.getMethod();
+
+        // 1. GET 요청이면 바로 통과
+        if ("GET".equalsIgnoreCase(method)) {
+            return true;
+        }
+
+        Object memberId = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes())
+                .getRequest().getAttribute("memberId");
+
+        if (memberId == null) {
+            log.warn("member ID가 없습니다. 중복 체크를 패스합니다.");
+            return true; // memberId가 없으면 중복 체크 패스
+        }
+
+        if(!checkAndSetRequest(memberId.toString())) {
+            throw new DuplicateRequestException();
+        }
+
+        return true;
+    }
+}

--- a/module-api/src/main/java/com/checkping/api/auth/interceptor/DuplicatedClickPrevent.java
+++ b/module-api/src/main/java/com/checkping/api/auth/interceptor/DuplicatedClickPrevent.java
@@ -18,14 +18,14 @@ import java.util.concurrent.TimeUnit;
 public class DuplicatedClickPrevent implements HandlerInterceptor {
 
     private final StringRedisTemplate stringRedisTemplate;
-    private static final String PREFIX = "CLICK:ID:";
 
     public DuplicatedClickPrevent(@Qualifier("redisTemplateForDuplicatedClick") StringRedisTemplate stringRedisTemplate) {
         this.stringRedisTemplate = stringRedisTemplate;
     }
 
-    public boolean checkAndSetRequest(String email) {
-        String key = PREFIX + email;
+    public boolean checkAndSetRequest(String memberId, String requestURI, String method) {
+        // 요청별로 고유한 키 생성: "CLICK:MEMBERID:요청경로:MEMBERID"
+        String key = "CLICK:" + memberId + ":" + method + ":" + requestURI + ":" + memberId;
         Boolean success = stringRedisTemplate.opsForValue()
                 .setIfAbsent(key, "LOCK", 1, TimeUnit.SECONDS);
 
@@ -42,7 +42,7 @@ public class DuplicatedClickPrevent implements HandlerInterceptor {
             return true;
         }
 
-        // 2. 특정 경로 PUT 요청 제외
+        // 2. 특정 경로 PUT 요청은 중복 체크 제외
         if ("PUT".equalsIgnoreCase(method) && requestURI.matches("^/projects/\\d+/progress-steps/orders$")) {
             return true;
         }
@@ -55,7 +55,7 @@ public class DuplicatedClickPrevent implements HandlerInterceptor {
             return true; // memberId가 없으면 중복 체크 패스
         }
 
-        if(!checkAndSetRequest(memberId.toString())) {
+        if (!checkAndSetRequest(memberId.toString(), requestURI, method)) {
             throw new DuplicateRequestException();
         }
 

--- a/module-api/src/main/java/com/checkping/api/auth/interceptor/DuplicatedClickPrevent.java
+++ b/module-api/src/main/java/com/checkping/api/auth/interceptor/DuplicatedClickPrevent.java
@@ -27,7 +27,7 @@ public class DuplicatedClickPrevent implements HandlerInterceptor {
     public boolean checkAndSetRequest(String email) {
         String key = PREFIX + email;
         Boolean success = stringRedisTemplate.opsForValue()
-                .setIfAbsent(key, "LOCK", 3, TimeUnit.SECONDS);
+                .setIfAbsent(key, "LOCK", 1, TimeUnit.SECONDS);
 
         return success != null && success;
     }
@@ -39,6 +39,11 @@ public class DuplicatedClickPrevent implements HandlerInterceptor {
 
         // 1. GET 요청이면 바로 통과
         if ("GET".equalsIgnoreCase(method)) {
+            return true;
+        }
+
+        // 2. 특정 경로 PUT 요청 제외
+        if ("PUT".equalsIgnoreCase(method) && requestURI.matches("^/projects/\\d+/progress-steps/orders$")) {
             return true;
         }
 

--- a/module-common/src/main/java/com/checkping/common/config/RedisConfig.java
+++ b/module-common/src/main/java/com/checkping/common/config/RedisConfig.java
@@ -3,6 +3,7 @@ package com.checkping.common.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -29,6 +30,16 @@ public class RedisConfig {
     public RedisConnectionFactory redisConnectionFactoryForInactiveMembers() {
         LettuceConnectionFactory factory = new LettuceConnectionFactory(redisHost, redisPort);
         factory.setDatabase(1);
+        factory.afterPropertiesSet();  // 필수 초기화 호출
+        return factory;
+    }
+
+    // 2번 저장소 사용 - 중복 클릭 방지
+    @Bean
+    public RedisConnectionFactory redisConnectionFactoryForDuplicatedClick() {
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(redisHost, redisPort);
+        factory.setDatabase(2);
+        factory.afterPropertiesSet();  // 필수 초기화 호출
         return factory;
     }
 
@@ -42,7 +53,13 @@ public class RedisConfig {
     }
 
     @Bean // 1번 저장소 사용
+    @Primary
     public StringRedisTemplate redisTemplateForInactiveMembers() {
         return new StringRedisTemplate(redisConnectionFactoryForInactiveMembers());
+    }
+
+    @Bean // 2번 저장소 사용 (중복 클릭 방지)
+    public StringRedisTemplate redisTemplateForDuplicatedClick() {
+        return new StringRedisTemplate(redisConnectionFactoryForDuplicatedClick());
     }
 }

--- a/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
+++ b/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
@@ -54,6 +54,12 @@ public enum ErrorCode {
     INACTIVE_OR_DELETED_MEMBER(HttpStatus.CONFLICT, "비활성화 또는 삭제된 회원입니다."),
 
     /*
+        429 Too Many Requests
+    */
+    ALREADY_PROCESSING_REQUEST(HttpStatus.TOO_MANY_REQUESTS, "이미 처리 중인 요청입니다."),
+
+
+    /*
         500 Internal Server Error
     */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),

--- a/module-service/src/main/java/com/checkping/exception/request/DuplicateRequestException.java
+++ b/module-service/src/main/java/com/checkping/exception/request/DuplicateRequestException.java
@@ -1,0 +1,17 @@
+package com.checkping.exception.request;
+
+import com.checkping.common.enums.ErrorCode;
+import com.checkping.common.exception.BaseException;
+
+public class DuplicateRequestException extends BaseException {
+
+    private ErrorCode errorCode;
+
+    public DuplicateRequestException() {
+        super(ErrorCode.ALREADY_PROCESSING_REQUEST);
+    }
+
+    public DuplicateRequestException(String message) {
+        super(message, ErrorCode.ALREADY_PROCESSING_REQUEST);
+    }
+}

--- a/module-service/src/main/java/com/checkping/service/member/MemberServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/member/MemberServiceImpl.java
@@ -46,11 +46,12 @@ public class MemberServiceImpl implements MemberService {
     private final CurrentMemberUtil currentMemberUtil;
     private final ProjectQueryRepository projectQueryRepository;
     private final RedisConnectionCheckService redisConnectionCheckService;
-    private final StringRedisTemplate redisTemplateForInactiveMemers;
+    private final StringRedisTemplate redisTemplateForInactiveMembers;
 
 
     // 아이디로 회원 조회
     @Override
+    @Transactional(readOnly = true)
     public MemberResponseDto getMemberById(Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(
@@ -59,6 +60,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public MemberListResponseDto getAllMembersWithFilters(
             int page,
             int size,
@@ -127,6 +129,7 @@ public class MemberServiceImpl implements MemberService {
 
     // 회원 등록
     @Override
+    @Transactional
     public MemberResponseDto registerMember(MemberRegisterDto dto) {
         // 이메일 중복 체크
         if (memberRepository.existsByEmail(dto.getEmail())) {
@@ -153,6 +156,7 @@ public class MemberServiceImpl implements MemberService {
 
     // 회원 정보 수정
     @Override
+    @Transactional
     public MemberResponseDto updateMember(Long memberId, MemberUpdateDto dto) {
         // 기존 회원 찾기
         Member existingMember = memberRepository.findById(memberId)
@@ -176,6 +180,7 @@ public class MemberServiceImpl implements MemberService {
 
     // 비밀번호 변경
     @Override
+    @Transactional
     public void changePassword(Long memberId, ChangePasswordDto dto) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(
@@ -209,6 +214,7 @@ public class MemberServiceImpl implements MemberService {
 
     // 회원 탈퇴
     @Override
+    @Transactional
     public void deleteMember(Long memberId, String reasonForDelete) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(
@@ -221,7 +227,7 @@ public class MemberServiceImpl implements MemberService {
         memberRepository.save(member);
         // Redis 1번 저장소에 탈퇴처리된 회원 ID 저장
         if(redisConnectionCheckService.isRedisAvailable()){
-            redisTemplateForInactiveMemers.opsForValue().set("deleted:member:" + memberId, "true", 24, TimeUnit.HOURS);
+            redisTemplateForInactiveMembers.opsForValue().set("deleted:member:" + memberId, "true", 24, TimeUnit.HOURS);
         }
     }
 
@@ -296,6 +302,7 @@ public class MemberServiceImpl implements MemberService {
      *  관리자가 회원을 활성화 처리합니다. - activateAccount
      *  */
     @Override
+    @Transactional
     public void activateMember(Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(
@@ -309,8 +316,8 @@ public class MemberServiceImpl implements MemberService {
 
         // Redis 1번 저장소에 비활성화된 회원 ID 삭제
         if(redisConnectionCheckService.isRedisAvailable()){
-            redisTemplateForInactiveMemers.delete("inactive:member:" + memberId);
-            redisTemplateForInactiveMemers.delete("deleted:member:" + memberId);
+            redisTemplateForInactiveMembers.delete("inactive:member:" + memberId);
+            redisTemplateForInactiveMembers.delete("deleted:member:" + memberId);
         }
     }
 
@@ -319,6 +326,7 @@ public class MemberServiceImpl implements MemberService {
      * 관리자가 회원을 비활성화 처리합니다. - inactiveAccount
      * */
     @Override
+    @Transactional
     public void deactivateMember(Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(
@@ -336,11 +344,12 @@ public class MemberServiceImpl implements MemberService {
 
         // Redis 1번 저장소에 비활성화된 회원 ID 저장
         if(redisConnectionCheckService.isRedisAvailable()){
-            redisTemplateForInactiveMemers.opsForValue().set("inactive:member:" + memberId, "true");
+            redisTemplateForInactiveMembers.opsForValue().set("inactive:member:" + memberId, "true");
         }
     }
 
     @Override
+    @Transactional(readOnly = true)
     public String getMemberStatus(Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(


### PR DESCRIPTION
# 🚀 Pull Request

**[Redis 상태 확인 후 중복 클릭 방지 인터셉터 등록]**

## #️⃣ 연관된 이슈

#508

## 📋 작업 내용
  - Redis 상태 확인 후 중복 클릭 방지 인터셉터 등록
  - `InterceptorMvcConfig`에서 `redisConnectionCheckService.isRedisAvailable()`을 활용하여 Redis가 활성화된 경우에만 `DuplicatedClickPrevent` 인터셉터 등록
  - 모든 요청(`/**`)에 대해 중복 클릭 방지를 적용하되, 로그인(`/login`), 토큰 재발급(`/reissue`), API 문서(`/swagger-ui/**`, `/v3/api-docs/**`) 요청 및 GET요청은 제외
  - 불필요한 인터셉터 등록을 방지하여 성능 최적화 및 안정성 강화

## ✅ 변경 사항
- `InterceptorMvcConfig`에 Redis 상태 확인 로직 추가
- `DuplicatedClickPrevent` 인터셉터를 특정 조건에서만 적용
- `excludePathPatterns()`을 통해 특정 엔드포인트 예외 처리

## 🔍 테스트 방법
1. Redis가 활성화된 상태에서 `/login`을 여러 번 요청 → 중복 요청이 차단되지 않아야 함
2. Redis가 활성화된 상태에서 다른 API(회원정보 수정 등) 요청을 빠르게 여러 번 수행 → 429 응답 확인
3. Redis가 비활성화된 상태에서 서버 실행 → 인터셉터가 등록되지 않아야 함

## 🏷 기타 사항
- 중복 요청 방지 로직이 정상적으로 동작하는지 추가적인 테스트 필요
- 인터셉터 적용 범위 조정 가능성 검토

## 설명

```java
public boolean checkAndSetRequest(String memberId, String requestURI, String method) {
    // 요청별로 고유한 키 생성: "CLICK:MEMBERID:요청유형:요청경로:MEMBERID"
    String key = "CLICK:" + memberId + ":" + method + ":" + requestURI + ":" + memberId;
    Boolean success = stringRedisTemplate.opsForValue()
            .setIfAbsent(key, "LOCK", 1, TimeUnit.SECONDS);

    return success != null && success;
}

// setIfAbsent(key, "LOCK", 1, TimeUnit.SECONDS); 부분은 Redis에 Lock을 설정하는 코드
// setIfAbsent(Redis SETNX) 명령어를 사용하여 중복 요청을 방지 : 같은 키가 존재하지 않을 경우에만 값을 설정하며, 1초 동안 유지되도록 TTL(Time-To-Live)을 설정
// 동일한 요청이 1초 내에 다시 들어올 경우 중복 요청으로 간주하여 차단합니다.
