### PR TITLE
fix : 결재 권한 체크 시 쿼리에 넣어줄 변수 수정

### DIFF
--- a/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalRepository.java
+++ b/module-infra/src/main/java/com/checkping/infra/repository/approval/ApprovalRepository.java
@@ -16,9 +16,9 @@ public interface ApprovalRepository extends JpaRepository<Approval, Long>, Appro
         + "ORDER BY COALESCE(c.parent.id, c.id), c.regAt ASC")
     Optional<Approval> getByIdWithComments(@Param("approvalId") Long approvalId);
 
-    boolean existsByProjectIdAndId(Long projectId, Long approvalId);
+    boolean existsByProjectIdAndId(Long projectId, Long id);
 
-    boolean existsByIdAndRegisterId(Long approvalId, Long registerId);
+    boolean existsByIdAndRegisterId(Long id, Long registerId);
 
     boolean existsByProgressStepId(Long progressStepId);
 }


### PR DESCRIPTION
# 🚀 Pull Request

**[결재 권한 체크 시 쿼리에 넣어줄 변수 수정]**

## #️⃣ 연관된 이슈

- #519

## 📋 작업 내용

- 쿼리 메서드 매개변수명 변경 (- approvalId -> id)