### PR TITLE
ERROR/427 공지사항 에러 해결

### DIFF
--- a/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
+++ b/module-common/src/main/java/com/checkping/common/enums/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     DELETED_MEMBER(HttpStatus.CONFLICT, "삭제된 회원입니다."),
     INACTIVE_MEMBER(HttpStatus.CONFLICT, "비활성화된 회원입니다."),
     INACTIVE_OR_DELETED_MEMBER(HttpStatus.CONFLICT, "비활성화 또는 삭제된 회원입니다."),
+    DELETED_NOTICE(HttpStatus.CONFLICT, "삭제된 공지사항입니다"),
 
     /*
         500 Internal Server Error

--- a/module-service/src/main/java/com/checkping/dto/notice/response/NoticeGetListWithIsdeletedResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/notice/response/NoticeGetListWithIsdeletedResponse.java
@@ -40,7 +40,7 @@ public class NoticeGetListWithIsdeletedResponse implements NoticeGetListResponse
                 .category(notice.getCategory())
                 .priority(notice.getPriority())
                 .isDeleted(notice.getIsDeleted() != null && notice.getIsDeleted() ? "Y" : "N")
-                .regAt(notice.getUpdatedAt())
+                .regAt(notice.getRegAt())
                 .updatedAt(notice.getUpdatedAt())
                 .build();
     }

--- a/module-service/src/main/java/com/checkping/dto/notice/response/NoticeGetListWithoutIsdeletedResponse.java
+++ b/module-service/src/main/java/com/checkping/dto/notice/response/NoticeGetListWithoutIsdeletedResponse.java
@@ -39,7 +39,7 @@ public class NoticeGetListWithoutIsdeletedResponse implements NoticeGetListRespo
                 .title(notice.getTitle())
                 .category(notice.getCategory())
                 .priority(notice.getPriority())
-                .regAt(notice.getUpdatedAt())
+                .regAt(notice.getRegAt())
                 .updatedAt(notice.getUpdatedAt())
                 .build();
     }

--- a/module-service/src/main/java/com/checkping/service/notice/NoticeServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/notice/NoticeServiceImpl.java
@@ -79,16 +79,30 @@ public class NoticeServiceImpl implements NoticeService {
             }
         }
 
-        List<String> fileUrls = noticeUpdateRequest.getFileInfoListSafe().stream()
-                .map(fileInfo -> fileInfo.saveName() + "|" + fileInfo.url())
-                .collect(Collectors.toList());
+        List<String> newFileUrls = new ArrayList<>();
+        if (noticeUpdateRequest.getFileInfoList() != null) {
+            newFileUrls = noticeUpdateRequest.getFileInfoListSafe().stream()
+                    .map(fileInfo -> fileInfo.saveName() + "|" + fileInfo.url())
+                    .collect(Collectors.toList());
+        }
+
+        List<String> existingFileUrls = notice.getNoticeFileUrls();
+        List<String> filesToDelete = new ArrayList<>(existingFileUrls);
+
+        if (newFileUrls.isEmpty()) {
+            filesToDelete.addAll(existingFileUrls);
+        } else {
+            filesToDelete.removeAll(newFileUrls);
+        }
+
+        List<String> updatedFileUrls = new ArrayList<>(newFileUrls);
 
         notice.updateNotice(
                 noticeUpdateRequest.getTitle(),
                 noticeUpdateRequest.getContent() != null ? noticeUpdateRequest.convertContentToJson() : null,
                 noticeUpdateRequest.getCategory(),
                 noticeUpdateRequest.getPriority(),
-                fileUrls.isEmpty() ? new ArrayList<>() : fileUrls // 파일이 없으면 null 유지
+                updatedFileUrls
         );
 
         return NoticeWithIsdeletedResponse.toDto(notice);

--- a/module-service/src/main/java/com/checkping/service/notice/NoticeServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/notice/NoticeServiceImpl.java
@@ -66,7 +66,7 @@ public class NoticeServiceImpl implements NoticeService {
                 .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND));
 
         if (notice.getIsDeleted()) {
-            throw new BaseException(ErrorCode.BAD_REQUEST);
+            throw new BaseException(ErrorCode.DELETED_NOTICE);
         }
 
         if (noticeUpdateRequest.getPriority() != null) {
@@ -101,7 +101,7 @@ public class NoticeServiceImpl implements NoticeService {
                 .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND));
 
         if (notice.getIsDeleted()) {
-            throw new BaseException(ErrorCode.BAD_REQUEST);
+            throw new BaseException(ErrorCode.DELETED_NOTICE);
         }
 
         notice.markAsDeleted();

--- a/module-service/src/main/java/com/checkping/service/notice/NoticeServiceImpl.java
+++ b/module-service/src/main/java/com/checkping/service/notice/NoticeServiceImpl.java
@@ -71,7 +71,7 @@ public class NoticeServiceImpl implements NoticeService {
 
         if (noticeUpdateRequest.getPriority() != null) {
             Notice.Priority priority = Notice.Priority.valueOf(noticeUpdateRequest.getPriority());
-            if (priority == Notice.Priority.EMERGENCY) {
+            if (priority == Notice.Priority.EMERGENCY&& !notice.getPriority().equals(Notice.Priority.EMERGENCY)) {
                 long emergencyNoticeCount = noticeRepository.countByPriorityAndIsDeletedFalse(Notice.Priority.EMERGENCY);
                 if (emergencyNoticeCount >= 3) {
                     throw new BaseException("긴급 공지사항은 최대 3개 등록 가능합니다", ErrorCode.BAD_REQUEST);


### PR DESCRIPTION
# 🚀 Pull Request

각종 이슈 해결

## #️⃣ 연관된 이슈

#532

## 📋 작업 내용

- 삭제된 공지사항을 삭제나 수정 시도할 때 예외메세지 수정
- 긴급 공지사항 수정 시 긴급공지사항이 3개라면서 수정 안되는 오류 해결
- 첨부파일 있는 공지사항이 수정 안되는 것 해결
- 공지사항 수정 시 목록조회에서 확인가능한 등록일자도 수정일자로 수정되는 문제 해결
