### PR TITLE
HOTFIX: Redis 저장소 문제 해결 (@Qualifier 적용)

### DIFF
--- a/module-service/src/main/java/com/checkping/service/member/auth/TokenBlacklistService.java
+++ b/module-service/src/main/java/com/checkping/service/member/auth/TokenBlacklistService.java
@@ -1,5 +1,6 @@
 package com.checkping.service.member.auth;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -10,7 +11,7 @@ public class TokenBlacklistService {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public TokenBlacklistService(RedisTemplate<String, String> redisTemplate) {
+    public TokenBlacklistService(@Qualifier("redisTemplate") RedisTemplate<String, String> redisTemplate) {
         this.redisTemplate = redisTemplate;
     }
 


### PR DESCRIPTION
# 🚀 Pull Request

**[TokenBlacklistService에서 @Qualifier("redisTemplate") 적용하여 0번 저장소 강제 지정]**

## #️⃣ 연관된 이슈

#537 

## 📋 작업 내용

- 블랙리스트된 토큰이 레디스0번저장소가 아닌 1번 저장소에 저장되는 버그 수정
- okenBlacklistService에서 @Qualifier("redisTemplate") 적용하여 0번 저장소 강제 지정